### PR TITLE
Align PH Core observation vitals form with questionnaire, mapper, and list UI

### DIFF
--- a/resources/seeds/Mapping/observation-create-connectathon.yaml
+++ b/resources/seeds/Mapping/observation-create-connectathon.yaml
@@ -9,7 +9,7 @@ body:
     - encounterRef: "{{ %QuestionnaireResponse.answers('encounter') }}"
     - performerRef: "{{ %QuestionnaireResponse.answers('performer') }}"
     - status: "{{ %QuestionnaireResponse.answers('status') }}"
-    - statusCode: "{{ %status.coding.code }}"
+    - statusCode: "{{ %status.code }}"
     - effectiveDateTime: "{{ %QuestionnaireResponse.answers('effective-date-time') }}"
     - temperature: "{{ %QuestionnaireResponse.answers('temperature') }}"
     - bloodPressureSystolic: "{{ %QuestionnaireResponse.answers('blood-pressure-systolic') }}"
@@ -59,12 +59,11 @@ body:
             unit: °C
             system: http://unitsofmeasure.org
             code: Cel
-          "{% merge %}":
-            - "{% if %encounterRef.exists() %}":
-                encounter: "{{ %encounterRef }}"
+          encounter: "{{ %encounterRef }}"
+          performer:
             - "{% if %performerRef.exists() %}":
-                performer:
-                  - "{{ %performerRef }}"
+                reference: "{{ %performerRef.reference }}"
+                display: "{{ %performerRef.display }}"
 
     - "{% if %bloodPressureSystolic.exists() and %bloodPressureDiastolic.exists() %}":
         request:
@@ -95,7 +94,7 @@ body:
           effectiveDateTime: "{{ %effectiveDateTime }}"
           text:
             status: generated
-            div: "<div xmlns='http://www.w3.org/1999/xhtml'>PH Core Observation — blood pressure {{ %bloodPressureSystolic.value }}/{{ %bloodPressureDiastolic.value }} mmHg for {{ %patientLabel }}{{ iif(%bloodPressureArm.display.exists(), ' (' + %bloodPressureArm.display + ')', '') }}{{ iif(%bloodPressurePosition.display.exists(), ', ' + %bloodPressurePosition.display, '') }}.</div>"
+            div: "<div xmlns='http://www.w3.org/1999/xhtml'>PH Core Observation — blood pressure {{ %bloodPressureSystolic.value }}/{{ %bloodPressureDiastolic.value }} mmHg for {{ %patientLabel }}.</div>"
           component:
             - code:
                 coding:
@@ -117,21 +116,20 @@ body:
                 unit: mmHg
                 system: http://unitsofmeasure.org
                 code: mm[Hg]
-          "{% merge %}":
-            - "{% if %encounterRef.exists() %}":
-                encounter: "{{ %encounterRef }}"
+          encounter: "{{ %encounterRef }}"
+          performer:
             - "{% if %performerRef.exists() %}":
-                performer:
-                  - "{{ %performerRef }}"
-            - "{% if %bloodPressureArm.exists() %}":
-                bodySite:
-                  coding:
-                    - "{{ %bloodPressureArm }}"
-            - "{% if %bloodPressurePosition.exists() %}":
-                method:
-                  coding:
-                    - "{{ %bloodPressurePosition }}"
-                  text: "{{ %bloodPressurePosition.display }}"
+                reference: "{{ %performerRef.reference }}"
+                display: "{{ %performerRef.display }}"
+          bodySite:
+            "{% if %bloodPressureArm.exists() %}":
+              coding:
+                - "{{ %bloodPressureArm }}"
+          method:
+            "{% if %bloodPressurePosition.exists() %}":
+              coding:
+                - "{{ %bloodPressurePosition }}"
+              text: "{{ %bloodPressurePosition.display }}"
 
     - "{% if %pulseRate.exists() %}":
         request:
@@ -165,12 +163,11 @@ body:
             unit: /min
             system: http://unitsofmeasure.org
             code: /min
-          "{% merge %}":
-            - "{% if %encounterRef.exists() %}":
-                encounter: "{{ %encounterRef }}"
+          encounter: "{{ %encounterRef }}"
+          performer:
             - "{% if %performerRef.exists() %}":
-                performer:
-                  - "{{ %performerRef }}"
+                reference: "{{ %performerRef.reference }}"
+                display: "{{ %performerRef.display }}"
 
     - "{% if %respiratoryRate.exists() %}":
         request:
@@ -204,12 +201,11 @@ body:
             unit: /min
             system: http://unitsofmeasure.org
             code: /min
-          "{% merge %}":
-            - "{% if %encounterRef.exists() %}":
-                encounter: "{{ %encounterRef }}"
+          encounter: "{{ %encounterRef }}"
+          performer:
             - "{% if %performerRef.exists() %}":
-                performer:
-                  - "{{ %performerRef }}"
+                reference: "{{ %performerRef.reference }}"
+                display: "{{ %performerRef.display }}"
 
     - "{% if %oxygenSaturation.exists() %}":
         request:
@@ -243,12 +239,11 @@ body:
             unit: '%'
             system: http://unitsofmeasure.org
             code: '%'
-          "{% merge %}":
-            - "{% if %encounterRef.exists() %}":
-                encounter: "{{ %encounterRef }}"
+          encounter: "{{ %encounterRef }}"
+          performer:
             - "{% if %performerRef.exists() %}":
-                performer:
-                  - "{{ %performerRef }}"
+                reference: "{{ %performerRef.reference }}"
+                display: "{{ %performerRef.display }}"
 
     - "{% if %height.exists() %}":
         request:
@@ -282,12 +277,11 @@ body:
             unit: cm
             code: cm
             system: http://unitsofmeasure.org
-          "{% merge %}":
-            - "{% if %encounterRef.exists() %}":
-                encounter: "{{ %encounterRef }}"
+          encounter: "{{ %encounterRef }}"
+          performer:
             - "{% if %performerRef.exists() %}":
-                performer:
-                  - "{{ %performerRef }}"
+                reference: "{{ %performerRef.reference }}"
+                display: "{{ %performerRef.display }}"
 
     - "{% if %weight.exists() %}":
         request:
@@ -321,12 +315,11 @@ body:
             unit: kg
             system: http://unitsofmeasure.org
             code: kg
-          "{% merge %}":
-            - "{% if %encounterRef.exists() %}":
-                encounter: "{{ %encounterRef }}"
+          encounter: "{{ %encounterRef }}"
+          performer:
             - "{% if %performerRef.exists() %}":
-                performer:
-                  - "{{ %performerRef }}"
+                reference: "{{ %performerRef.reference }}"
+                display: "{{ %performerRef.display }}"
 
     - "{% if %bmi.exists() %}":
         request:
@@ -360,9 +353,8 @@ body:
             unit: kg/m2
             system: http://unitsofmeasure.org
             code: kg/m2
-          "{% merge %}":
-            - "{% if %encounterRef.exists() %}":
-                encounter: "{{ %encounterRef }}"
+          encounter: "{{ %encounterRef }}"
+          performer:
             - "{% if %performerRef.exists() %}":
-                performer:
-                  - "{{ %performerRef }}"
+                reference: "{{ %performerRef.reference }}"
+                display: "{{ %performerRef.display }}"

--- a/resources/seeds/Mapping/observation-create-connectathon.yaml
+++ b/resources/seeds/Mapping/observation-create-connectathon.yaml
@@ -6,17 +6,23 @@ body:
     - patient: "{{ %QuestionnaireResponse.answers('patient') }}"
     - patientId: "{{ %patient.reference.replace('Patient/', '') }}"
     - patientName: "{{ %patient.display }}"
+    - encounterRef: "{{ %QuestionnaireResponse.answers('encounter') }}"
+    - performerRef: "{{ %QuestionnaireResponse.answers('performer') }}"
+    - status: "{{ %QuestionnaireResponse.answers('status') }}"
+    - statusCode: "{{ iif(%status.code.exists(), %status.code, iif(%status.exists(), %status, 'final')) }}"
+    - effectiveDateTime: "{{ %QuestionnaireResponse.answers('effective-date-time') }}"
     - temperature: "{{ %QuestionnaireResponse.answers('temperature') }}"
     - bloodPressureSystolic: "{{ %QuestionnaireResponse.answers('blood-pressure-systolic') }}"
     - bloodPressureDiastolic: "{{ %QuestionnaireResponse.answers('blood-pressure-diastolic') }}"
     - bloodPressureArm: "{{ %QuestionnaireResponse.answers('blood-pressure-arm') }}"
-    - bloodPressurePosition: "{{ %QuestionnaireResponse.answers('blood-pressure-positions') }}"
+    - bloodPressurePosition: "{{ %QuestionnaireResponse.answers('blood-pressure-position') }}"
     - pulseRate: "{{ %QuestionnaireResponse.answers('pulse-rate') }}"
     - respiratoryRate: "{{ %QuestionnaireResponse.answers('respiratory-rate') }}"
     - oxygenSaturation: "{{ %QuestionnaireResponse.answers('oxygen-saturation') }}"
     - height: "{{ %QuestionnaireResponse.answers('height') }}"
     - weight: "{{ %QuestionnaireResponse.answers('weight') }}"
     - bmi: "{{ %QuestionnaireResponse.answers('bmi') }}"
+    - patientLabel: "{{ iif(%patientName.exists(), %patientName, 'Patient/' + %patientId) }}"
 
   resourceType: Bundle
   type: transaction
@@ -29,8 +35,13 @@ body:
           resourceType: Observation
           meta:
             profile:
-            - urn://example.com/ph-core/fhir/StructureDefinition/ph-core-observation
-          status: final
+              - https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-observation
+          status: "{{ %statusCode }}"
+          category:
+            - coding:
+                - system: http://terminology.hl7.org/CodeSystem/observation-category
+                  code: vital-signs
+                  display: Vital Signs
           code:
             coding:
               - system: http://loinc.org
@@ -39,12 +50,21 @@ body:
           subject:
             reference: "Patient/{{ %patientId }}"
             display: "{{ %patientName }}"
-          effectiveDateTime: "{{ now() }}"
+          effectiveDateTime: "{{ %effectiveDateTime }}"
+          text:
+            status: generated
+            div: "<div xmlns='http://www.w3.org/1999/xhtml'>PH Core Observation — body temperature {{ %temperature.value }} °C for {{ %patientLabel }}.</div>"
           valueQuantity:
             value: "{{ %temperature.value }}"
-            unit: celsius
+            unit: °C
             system: http://unitsofmeasure.org
-            code: celsius
+            code: Cel
+          "{% merge %}":
+            - "{% if %encounterRef.exists() %}":
+                encounter: "{{ %encounterRef }}"
+            - "{% if %performerRef.exists() %}":
+                performer:
+                  - "{{ %performerRef }}"
 
     - "{% if %bloodPressureSystolic.exists() and %bloodPressureDiastolic.exists() %}":
         request:
@@ -54,22 +74,28 @@ body:
           resourceType: Observation
           meta:
             profile:
-            - urn://example.com/ph-core/fhir/StructureDefinition/ph-core-observation
-          status: final
+              - https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-observation
+              - http://hl7.org/fhir/StructureDefinition/vitalsigns
+              - http://hl7.org/fhir/StructureDefinition/bp
+          status: "{{ %statusCode }}"
+          category:
+            - coding:
+                - system: http://terminology.hl7.org/CodeSystem/observation-category
+                  code: vital-signs
+                  display: Vital Signs
           code:
             coding:
               - system: http://loinc.org
                 code: 85354-9
-                display: Blood pressure
+                display: Blood pressure panel with all children optional
+            text: Blood pressure systolic & diastolic
           subject:
             reference: "Patient/{{ %patientId }}"
             display: "{{ %patientName }}"
-          bodySite:
-            "{% if %bloodPressureArm.exists() or %bloodPressurePosition.exists() %}":
-              coding:
-                - "{{ %bloodPressureArm }}"
-                - "{{ %bloodPressurePosition }}"
-          effectiveDateTime: "{{ now() }}"
+          effectiveDateTime: "{{ %effectiveDateTime }}"
+          text:
+            status: generated
+            div: "<div xmlns='http://www.w3.org/1999/xhtml'>PH Core Observation — blood pressure {{ %bloodPressureSystolic.value }}/{{ %bloodPressureDiastolic.value }} mmHg for {{ %patientLabel }}{{ iif(%bloodPressureArm.display.exists(), ' (' + %bloodPressureArm.display + ')', '') }}{{ iif(%bloodPressurePosition.display.exists(), ', ' + %bloodPressurePosition.display, '') }}.</div>"
           component:
             - code:
                 coding:
@@ -80,7 +106,7 @@ body:
                 value: "{{ %bloodPressureSystolic.value }}"
                 unit: mmHg
                 system: http://unitsofmeasure.org
-                code: mmHg
+                code: mm[Hg]
             - code:
                 coding:
                   - system: http://loinc.org
@@ -90,7 +116,22 @@ body:
                 value: "{{ %bloodPressureDiastolic.value }}"
                 unit: mmHg
                 system: http://unitsofmeasure.org
-                code: mmHg
+                code: mm[Hg]
+          "{% merge %}":
+            - "{% if %encounterRef.exists() %}":
+                encounter: "{{ %encounterRef }}"
+            - "{% if %performerRef.exists() %}":
+                performer:
+                  - "{{ %performerRef }}"
+            - "{% if %bloodPressureArm.exists() %}":
+                bodySite:
+                  coding:
+                    - "{{ %bloodPressureArm }}"
+            - "{% if %bloodPressurePosition.exists() %}":
+                method:
+                  coding:
+                    - "{{ %bloodPressurePosition }}"
+                  text: "{{ %bloodPressurePosition.display }}"
 
     - "{% if %pulseRate.exists() %}":
         request:
@@ -100,8 +141,13 @@ body:
           resourceType: Observation
           meta:
             profile:
-            - urn://example.com/ph-core/fhir/StructureDefinition/ph-core-observation
-          status: final
+              - https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-observation
+          status: "{{ %statusCode }}"
+          category:
+            - coding:
+                - system: http://terminology.hl7.org/CodeSystem/observation-category
+                  code: vital-signs
+                  display: Vital Signs
           code:
             coding:
               - system: http://loinc.org
@@ -110,12 +156,21 @@ body:
           subject:
             reference: "Patient/{{ %patientId }}"
             display: "{{ %patientName }}"
-          effectiveDateTime: "{{ now() }}"
+          effectiveDateTime: "{{ %effectiveDateTime }}"
+          text:
+            status: generated
+            div: "<div xmlns='http://www.w3.org/1999/xhtml'>PH Core Observation — heart rate {{ %pulseRate.value }} /min for {{ %patientLabel }}.</div>"
           valueQuantity:
             value: "{{ %pulseRate.value }}"
-            unit: bpm
+            unit: /min
             system: http://unitsofmeasure.org
-            code: bpm
+            code: /min
+          "{% merge %}":
+            - "{% if %encounterRef.exists() %}":
+                encounter: "{{ %encounterRef }}"
+            - "{% if %performerRef.exists() %}":
+                performer:
+                  - "{{ %performerRef }}"
 
     - "{% if %respiratoryRate.exists() %}":
         request:
@@ -125,8 +180,13 @@ body:
           resourceType: Observation
           meta:
             profile:
-            - urn://example.com/ph-core/fhir/StructureDefinition/ph-core-observation
-          status: final
+              - https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-observation
+          status: "{{ %statusCode }}"
+          category:
+            - coding:
+                - system: http://terminology.hl7.org/CodeSystem/observation-category
+                  code: vital-signs
+                  display: Vital Signs
           code:
             coding:
               - system: http://loinc.org
@@ -135,12 +195,21 @@ body:
           subject:
             reference: "Patient/{{ %patientId }}"
             display: "{{ %patientName }}"
-          effectiveDateTime: "{{ now() }}"
+          effectiveDateTime: "{{ %effectiveDateTime }}"
+          text:
+            status: generated
+            div: "<div xmlns='http://www.w3.org/1999/xhtml'>PH Core Observation — respiratory rate {{ %respiratoryRate.value }} /min for {{ %patientLabel }}.</div>"
           valueQuantity:
             value: "{{ %respiratoryRate.value }}"
-            unit: bpm
+            unit: /min
             system: http://unitsofmeasure.org
-            code: bpm
+            code: /min
+          "{% merge %}":
+            - "{% if %encounterRef.exists() %}":
+                encounter: "{{ %encounterRef }}"
+            - "{% if %performerRef.exists() %}":
+                performer:
+                  - "{{ %performerRef }}"
 
     - "{% if %oxygenSaturation.exists() %}":
         request:
@@ -150,22 +219,36 @@ body:
           resourceType: Observation
           meta:
             profile:
-            - urn://example.com/ph-core/fhir/StructureDefinition/ph-core-observation
-          status: final
+              - https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-observation
+          status: "{{ %statusCode }}"
+          category:
+            - coding:
+                - system: http://terminology.hl7.org/CodeSystem/observation-category
+                  code: vital-signs
+                  display: Vital Signs
           code:
             coding:
               - system: http://loinc.org
                 code: 59408-5
-                display: Oxygen saturation
+                display: Oxygen saturation in Arterial blood by Pulse oximetry
           subject:
             reference: "Patient/{{ %patientId }}"
             display: "{{ %patientName }}"
-          effectiveDateTime: "{{ now() }}"
+          effectiveDateTime: "{{ %effectiveDateTime }}"
+          text:
+            status: generated
+            div: "<div xmlns='http://www.w3.org/1999/xhtml'>PH Core Observation — oxygen saturation {{ %oxygenSaturation.value }}% for {{ %patientLabel }}.</div>"
           valueQuantity:
             value: "{{ %oxygenSaturation.value }}"
-            unit: "%"
+            unit: '%'
             system: http://unitsofmeasure.org
-            code: "%"
+            code: '%'
+          "{% merge %}":
+            - "{% if %encounterRef.exists() %}":
+                encounter: "{{ %encounterRef }}"
+            - "{% if %performerRef.exists() %}":
+                performer:
+                  - "{{ %performerRef }}"
 
     - "{% if %height.exists() %}":
         request:
@@ -175,8 +258,13 @@ body:
           resourceType: Observation
           meta:
             profile:
-            - urn://example.com/ph-core/fhir/StructureDefinition/ph-core-observation
-          status: final
+              - https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-observation
+          status: "{{ %statusCode }}"
+          category:
+            - coding:
+                - system: http://terminology.hl7.org/CodeSystem/observation-category
+                  code: vital-signs
+                  display: Vital Signs
           code:
             coding:
               - system: http://loinc.org
@@ -185,12 +273,21 @@ body:
           subject:
             reference: "Patient/{{ %patientId }}"
             display: "{{ %patientName }}"
-          effectiveDateTime: "{{ now() }}"
+          effectiveDateTime: "{{ %effectiveDateTime }}"
+          text:
+            status: generated
+            div: "<div xmlns='http://www.w3.org/1999/xhtml'>PH Core Observation — body height {{ %height.value }} cm for {{ %patientLabel }}.</div>"
           valueQuantity:
             value: "{{ %height.value }}"
             unit: cm
             code: cm
             system: http://unitsofmeasure.org
+          "{% merge %}":
+            - "{% if %encounterRef.exists() %}":
+                encounter: "{{ %encounterRef }}"
+            - "{% if %performerRef.exists() %}":
+                performer:
+                  - "{{ %performerRef }}"
 
     - "{% if %weight.exists() %}":
         request:
@@ -200,8 +297,13 @@ body:
           resourceType: Observation
           meta:
             profile:
-            - urn://example.com/ph-core/fhir/StructureDefinition/ph-core-observation
-          status: final
+              - https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-observation
+          status: "{{ %statusCode }}"
+          category:
+            - coding:
+                - system: http://terminology.hl7.org/CodeSystem/observation-category
+                  code: vital-signs
+                  display: Vital Signs
           code:
             coding:
               - system: http://loinc.org
@@ -210,12 +312,21 @@ body:
           subject:
             reference: "Patient/{{ %patientId }}"
             display: "{{ %patientName }}"
-          effectiveDateTime: "{{ now() }}"
+          effectiveDateTime: "{{ %effectiveDateTime }}"
+          text:
+            status: generated
+            div: "<div xmlns='http://www.w3.org/1999/xhtml'>PH Core Observation — body weight {{ %weight.value }} kg for {{ %patientLabel }}.</div>"
           valueQuantity:
             value: "{{ %weight.value }}"
             unit: kg
             system: http://unitsofmeasure.org
             code: kg
+          "{% merge %}":
+            - "{% if %encounterRef.exists() %}":
+                encounter: "{{ %encounterRef }}"
+            - "{% if %performerRef.exists() %}":
+                performer:
+                  - "{{ %performerRef }}"
 
     - "{% if %bmi.exists() %}":
         request:
@@ -225,19 +336,33 @@ body:
           resourceType: Observation
           meta:
             profile:
-            - urn://example.com/ph-core/fhir/StructureDefinition/ph-core-observation
-          status: final
+              - https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-observation
+          status: "{{ %statusCode }}"
+          category:
+            - coding:
+                - system: http://terminology.hl7.org/CodeSystem/observation-category
+                  code: vital-signs
+                  display: Vital Signs
           code:
             coding:
               - system: http://loinc.org
                 code: 39156-5
-                display: BMI
+                display: Body mass index (BMI) [Ratio]
           subject:
             reference: "Patient/{{ %patientId }}"
             display: "{{ %patientName }}"
-          effectiveDateTime: "{{ now() }}"
+          effectiveDateTime: "{{ %effectiveDateTime }}"
+          text:
+            status: generated
+            div: "<div xmlns='http://www.w3.org/1999/xhtml'>PH Core Observation — BMI {{ %bmi }} kg/m2 for {{ %patientLabel }}.</div>"
           valueQuantity:
             value: "{{ %bmi }}"
-            unit: "kg/m2"
+            unit: kg/m2
             system: http://unitsofmeasure.org
-            code: "kg/m2"
+            code: kg/m2
+          "{% merge %}":
+            - "{% if %encounterRef.exists() %}":
+                encounter: "{{ %encounterRef }}"
+            - "{% if %performerRef.exists() %}":
+                performer:
+                  - "{{ %performerRef }}"

--- a/resources/seeds/Mapping/observation-create-connectathon.yaml
+++ b/resources/seeds/Mapping/observation-create-connectathon.yaml
@@ -9,7 +9,7 @@ body:
     - encounterRef: "{{ %QuestionnaireResponse.answers('encounter') }}"
     - performerRef: "{{ %QuestionnaireResponse.answers('performer') }}"
     - status: "{{ %QuestionnaireResponse.answers('status') }}"
-    - statusCode: "{{ iif(%status.code.exists(), %status.code, iif(%status.exists(), %status, 'final')) }}"
+    - statusCode: "{{ %status.coding.code }}"
     - effectiveDateTime: "{{ %QuestionnaireResponse.answers('effective-date-time') }}"
     - temperature: "{{ %QuestionnaireResponse.answers('temperature') }}"
     - bloodPressureSystolic: "{{ %QuestionnaireResponse.answers('blood-pressure-systolic') }}"
@@ -22,7 +22,7 @@ body:
     - height: "{{ %QuestionnaireResponse.answers('height') }}"
     - weight: "{{ %QuestionnaireResponse.answers('weight') }}"
     - bmi: "{{ %QuestionnaireResponse.answers('bmi') }}"
-    - patientLabel: "{{ iif(%patientName.exists(), %patientName, 'Patient/' + %patientId) }}"
+    - patientLabel: "{{ %patientName | ('Patient/' + %patientId) }}"
 
   resourceType: Bundle
   type: transaction

--- a/resources/seeds/Observation/observation-single-ex.yaml
+++ b/resources/seeds/Observation/observation-single-ex.yaml
@@ -2,9 +2,9 @@ resourceType: Observation
 id: observation-single-ex
 meta:
   profile:
-    - "urn://example.com/ph-core/fhir/StructureDefinition/ph-core-observation"
-    - "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-    - "http://hl7.org/fhir/StructureDefinition/bp"
+    - https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-observation
+    - http://hl7.org/fhir/StructureDefinition/vitalsigns
+    - http://hl7.org/fhir/StructureDefinition/bp
 identifier:
   - system: "urn:ietf:rfc:3986"
     value: "urn:uuid:187e0c12-8dd2-67e2-99b2-bf273c878281"

--- a/resources/seeds/Observation/observation-single-ex.yaml
+++ b/resources/seeds/Observation/observation-single-ex.yaml
@@ -39,7 +39,7 @@ component:
       value: 120
       unit: mmHg
       system: http://unitsofmeasure.org
-      code: mmHg
+      code: mm[Hg]
   - code:
       coding:
         - system: http://loinc.org
@@ -49,7 +49,7 @@ component:
       value: 80
       unit: mmHg
       system: http://unitsofmeasure.org
-      code: mmHg
+      code: mm[Hg]
 text:
   status: generated
   div: >-

--- a/resources/seeds/Observation/observation-single-ex.yaml
+++ b/resources/seeds/Observation/observation-single-ex.yaml
@@ -5,70 +5,53 @@ meta:
     - https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-observation
     - http://hl7.org/fhir/StructureDefinition/vitalsigns
     - http://hl7.org/fhir/StructureDefinition/bp
-identifier:
-  - system: "urn:ietf:rfc:3986"
-    value: "urn:uuid:187e0c12-8dd2-67e2-99b2-bf273c878281"
-basedOn:
-  - identifier:
-      system: "https://acme.org/identifiers"
-      value: "1234"
+status: final
 category:
   - coding:
-      - code: vital-signs
-        system: "http://terminology.hl7.org/CodeSystem/observation-category"
-        display: "Vital Signs"
+      - system: http://terminology.hl7.org/CodeSystem/observation-category
+        code: vital-signs
+        display: Vital Signs
 code:
   coding:
-    - code: 85354-9
-      system: "http://loinc.org"
-      display: "Blood pressure panel with all children optional"
-  text: "Blood pressure systolic & diastolic"
-performer:
-  - reference: Practitioner/practitioner-single-ex
-interpretation:
-  - coding:
-      - code: L
-        system: "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation"
-        display: Low
-    text: "Below low normal"
-component:
-  - interpretation:
-      - coding:
-          - { code: N, system: "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation", display: Normal }
-        text: Normal
-    code:
-      coding:
-        - code: 8480-6
-          system: "http://loinc.org"
-          display: "Systolic blood pressure"
-    valueQuantity:
-      value: 107
-      code: "mm[Hg]"
-      system: "http://unitsofmeasure.org"
-      unit: mmHg
-  - interpretation:
-      - coding:
-          - { code: L, system: "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation", display: Low }
-        text: "Below low normal"
-    code:
-      coding:
-        - code: 8462-4
-          system: "http://loinc.org"
-          display: "Diastolic blood pressure"
-    valueQuantity:
-      value: 60
-      code: "mm[Hg]"
-      system: "http://unitsofmeasure.org"
-      unit: mmHg
-text:
-  status: generated
-  div: '<div xmlns="http://www.w3.org/1999/xhtml">On 17 September 2012, a blood pressure observation was recorded for Juan Dela Cruz. The systolic pressure was 107 mmHg (Normal), and the diastolic pressure was 60 mmHg (Below low normal). The measurement was taken from the right arm and performed by a practitioner.</div>'
-status: final
+    - system: http://loinc.org
+      code: '85354-9'
+      display: Blood pressure panel with all children optional
+  text: Blood pressure
 subject:
   reference: Patient/patient-single-ex
-effectiveDateTime: "2012-09-17"
+  display: Juan Dela Cruz
+effectiveDateTime: '2026-06-17T10:15:00+08:00'
+performer:
+  - reference: Practitioner/practitioner-single-ex
+    display: Maria Clara Santos
 bodySite:
   coding:
-    - code: "368209003"
-      system: "http://snomed.info/sct"
-      display: "Right arm"
+    - system: http://snomed.info/sct
+      code: '368209003'
+      display: Right arm
+component:
+  - code:
+      coding:
+        - system: http://loinc.org
+          code: '8480-6'
+          display: Systolic blood pressure
+    valueQuantity:
+      value: 120
+      unit: mmHg
+      system: http://unitsofmeasure.org
+      code: mmHg
+  - code:
+      coding:
+        - system: http://loinc.org
+          code: '8462-4'
+          display: Diastolic blood pressure
+    valueQuantity:
+      value: 80
+      unit: mmHg
+      system: http://unitsofmeasure.org
+      code: mmHg
+text:
+  status: generated
+  div: >-
+    <div xmlns="http://www.w3.org/1999/xhtml">PH Core blood pressure for Juan Dela Cruz —
+    120/80 mmHg, right arm, 17 June 2026.</div>

--- a/resources/seeds/Questionnaire/observation-create-connectathon.yaml
+++ b/resources/seeds/Questionnaire/observation-create-connectathon.yaml
@@ -258,6 +258,8 @@ item:
     linkId: blood-pressure
 resourceType: Questionnaire
 title: Observation create PH
+subjectType:
+  - Patient
 extension:
   - url: https://emr-core.beda.software/StructureDefinition/questionnaire-mapper
     valueReference:

--- a/resources/seeds/Questionnaire/observation-create-connectathon.yaml
+++ b/resources/seeds/Questionnaire/observation-create-connectathon.yaml
@@ -24,6 +24,105 @@ item:
       - url: >-
           http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource
         valueCode: Patient
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
+        valueExpression:
+          language: text/fhirpath
+          expression: '%Patient'
+  - text: Encounter
+    type: reference
+    linkId: encounter
+    extension:
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-choiceColumn
+        extension:
+          - url: path
+            valueString: >-
+              class.display + ' - ' + period.start.toString()
+          - url: forDisplay
+            valueBoolean: true
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-answerExpression
+        valueExpression:
+          language: application/x-fhir-query
+          expression: Encounter?patient={{%QuestionnaireResponse.repeat(item).where(linkId='patient').answer.valueReference.reference}}
+      - url: >-
+          http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource
+        valueCode: Encounter
+  - text: Performer
+    type: reference
+    linkId: performer
+    extension:
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-choiceColumn
+        extension:
+          - url: path
+            valueString: >-
+              name.given.first() + ' ' + name.family
+          - url: forDisplay
+            valueBoolean: true
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-answerExpression
+        valueExpression:
+          language: application/x-fhir-query
+          expression: Practitioner
+      - url: >-
+          http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource
+        valueCode: Practitioner
+  - text: Status
+    type: choice
+    linkId: status
+    required: true
+    answerOption:
+      - valueCoding:
+          system: http://hl7.org/fhir/observation-status
+          code: registered
+          display: Registered
+      - valueCoding:
+          system: http://hl7.org/fhir/observation-status
+          code: preliminary
+          display: Preliminary
+      - valueCoding:
+          system: http://hl7.org/fhir/observation-status
+          code: final
+          display: Final
+      - valueCoding:
+          system: http://hl7.org/fhir/observation-status
+          code: amended
+          display: Amended
+      - valueCoding:
+          system: http://hl7.org/fhir/observation-status
+          code: corrected
+          display: Corrected
+      - valueCoding:
+          system: http://hl7.org/fhir/observation-status
+          code: cancelled
+          display: Cancelled
+      - valueCoding:
+          system: http://hl7.org/fhir/observation-status
+          code: entered-in-error
+          display: Entered in Error
+      - valueCoding:
+          system: http://hl7.org/fhir/observation-status
+          code: unknown
+          display: Unknown
+    extension:
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
+        valueExpression:
+          language: text/fhirpath
+          expression: >-
+            %Questionnaire.repeat(item).where(linkId='status').answerOption.valueCoding.where(code='final').first()
+  - text: Effective date and time
+    type: dateTime
+    linkId: effective-date-time
+    required: true
+    extension:
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
+        valueExpression:
+          language: text/fhirpath
+          expression: now()
   - text: Height
     type: quantity
     linkId: height
@@ -46,13 +145,11 @@ item:
     type: decimal
     linkId: bmi
     readOnly: true
-    required: true
     extension:
       - url: >-
           http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression
         valueExpression:
           language: text/fhirpath
-          # expression: "%QuestionnaireResponse.item.where(linkId='weight').answer.valueQuantity.value"
           expression: >-
             (%QuestionnaireResponse.item.where(linkId='weight').answer.valueQuantity.value
             /
@@ -66,36 +163,36 @@ item:
     extension:
       - url: http://hl7.org/fhir/StructureDefinition/questionnaire-unit
         valueCoding:
-          code: Celsius
+          code: Cel
           system: http://unitsofmeasure.org
-          display: Celsius
+          display: °C
   - text: Oxygen saturation
     type: quantity
     linkId: oxygen-saturation
     extension:
       - url: http://hl7.org/fhir/StructureDefinition/questionnaire-unit
         valueCoding:
-          code: "%"
+          code: '%'
           system: http://unitsofmeasure.org
-          display: "%"
+          display: '%'
   - text: Pulse rate
     type: quantity
     linkId: pulse-rate
     extension:
       - url: http://hl7.org/fhir/StructureDefinition/questionnaire-unit
         valueCoding:
-          code: bpm
+          code: /min
           system: http://unitsofmeasure.org
-          display: bpm
+          display: /min
   - text: Respiratory Rate
     type: quantity
     linkId: respiratory-rate
     extension:
       - url: http://hl7.org/fhir/StructureDefinition/questionnaire-unit
         valueCoding:
-          code: bpm
+          code: /min
           system: http://unitsofmeasure.org
-          display: bpm
+          display: /min
   - item:
       - item:
           - text: BP systolic
@@ -104,7 +201,7 @@ item:
             extension:
               - url: http://hl7.org/fhir/StructureDefinition/questionnaire-unit
                 valueCoding:
-                  code: mmHg
+                  code: mm[Hg]
                   system: http://unitsofmeasure.org
                   display: mmHg
           - text: BP diastolic
@@ -113,24 +210,27 @@ item:
             extension:
               - url: http://hl7.org/fhir/StructureDefinition/questionnaire-unit
                 valueCoding:
-                  code: mmHg
+                  code: mm[Hg]
                   system: http://unitsofmeasure.org
                   display: mmHg
         type: group
         linkId: blood-pressure-systolic-diastolic
-      - text: Positions
+      - text: Position
         type: choice
-        linkId: blood-pressure-positions
+        linkId: blood-pressure-position
         answerOption:
           - valueCoding:
-              code: sitting
-              display: Sitting
+              system: http://snomed.info/sct
+              code: '33586001'
+              display: Sitting position
           - valueCoding:
-              code: lying
-              display: Lying
+              system: http://snomed.info/sct
+              code: '102538003'
+              display: Standing position
           - valueCoding:
-              code: standing
-              display: Standing
+              system: http://snomed.info/sct
+              code: '102541000'
+              display: Lying position
         extension:
           - url: http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl
             valueCodeableConcept:
@@ -141,11 +241,13 @@ item:
         linkId: blood-pressure-arm
         answerOption:
           - valueCoding:
-              code: biceps-left
-              display: Biceps left
+              system: http://snomed.info/sct
+              code: '368208006'
+              display: Left arm
           - valueCoding:
-              code: biceps-right
-              display: Biceps right
+              system: http://snomed.info/sct
+              code: '368209003'
+              display: Right arm
         extension:
           - url: http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl
             valueCodeableConcept:
@@ -160,6 +262,13 @@ extension:
   - url: https://emr-core.beda.software/StructureDefinition/questionnaire-mapper
     valueReference:
       reference: Mapping/observation-create-connectathon
+  - url: http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext
+    extension:
+      - url: name
+        valueCoding:
+          code: Patient
+      - url: type
+        valueCode: Patient
 status: active
 id: observation-create-connectathon
 url: observation-create

--- a/resources/seeds/Questionnaire/observation-create-connectathon.yaml
+++ b/resources/seeds/Questionnaire/observation-create-connectathon.yaml
@@ -1,77 +1,65 @@
+resourceType: Questionnaire
+id: observation-create-connectathon
+name: observation-create-connectathon
+title: Observation create PH
+status: active
+url: observation-create
+subjectType:
+  - Patient
 meta:
   profile:
     - https://emr-core.beda.software/StructureDefinition/fhir-emr-questionnaire
-name: observation-create-connectathon
+mapping:
+  - reference: Mapping/observation-create-connectathon
+launchContext:
+  - name:
+      code: Patient
+    type:
+      - Patient
 item:
-  - text: Patient
+  - linkId: patient
+    text: Patient
     type: reference
-    linkId: patient
     required: true
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-choiceColumn
-        extension:
-          - url: path
-            valueString: >-
-              name.given.first() + ' ' + name.family.first()
-          - url: forDisplay
-            valueBoolean: true
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-answerExpression
-        valueExpression:
-          language: application/x-fhir-query
-          expression: Patient
-      - url: >-
-          http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource
-        valueCode: Patient
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
-        valueExpression:
-          language: text/fhirpath
-          expression: '%Patient'
-  - text: Encounter
+    referenceResource:
+      - Patient
+    answerExpression:
+      language: application/x-fhir-query
+      expression: Patient
+    choiceColumn:
+      - forDisplay: true
+        path: name.given.first() + ' ' + name.family.first()
+    initialExpression:
+      language: text/fhirpath
+      expression: "%Patient"
+
+  - linkId: encounter
+    text: Encounter
     type: reference
-    linkId: encounter
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-choiceColumn
-        extension:
-          - url: path
-            valueString: >-
-              class.display + ' - ' + period.start.toString()
-          - url: forDisplay
-            valueBoolean: true
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-answerExpression
-        valueExpression:
-          language: application/x-fhir-query
-          expression: Encounter?patient={{%QuestionnaireResponse.repeat(item).where(linkId='patient').answer.valueReference.reference}}
-      - url: >-
-          http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource
-        valueCode: Encounter
-  - text: Performer
+    referenceResource:
+      - Encounter
+    answerExpression:
+      language: application/x-fhir-query
+      expression: "Encounter?patient={{%QuestionnaireResponse.repeat(item).where(linkId='patient').answer.valueReference.reference}}"
+    choiceColumn:
+      - forDisplay: true
+        path: class.display + ' - ' + period.start.toString()
+
+  - linkId: performer
+    text: Performer
     type: reference
-    linkId: performer
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-choiceColumn
-        extension:
-          - url: path
-            valueString: >-
-              name.given.first() + ' ' + name.family
-          - url: forDisplay
-            valueBoolean: true
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-answerExpression
-        valueExpression:
-          language: application/x-fhir-query
-          expression: Practitioner
-      - url: >-
-          http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource
-        valueCode: Practitioner
-  - text: Status
+    referenceResource:
+      - Practitioner
+    answerExpression:
+      language: application/x-fhir-query
+      expression: Practitioner
+    choiceColumn:
+      - forDisplay: true
+        path: name.given.first() + ' ' + name.family
+
+  - linkId: status
+    text: Status
     type: choice
-    linkId: status
     required: true
     answerOption:
       - valueCoding:
@@ -106,118 +94,111 @@ item:
           system: http://hl7.org/fhir/observation-status
           code: unknown
           display: Unknown
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
-        valueExpression:
-          language: text/fhirpath
-          expression: >-
-            %Questionnaire.repeat(item).where(linkId='status').answerOption.valueCoding.where(code='final').first()
-  - text: Effective date and time
+    initialExpression:
+      language: text/fhirpath
+      expression: "%Questionnaire.repeat(item).where(linkId='status').answerOption.valueCoding.where(code='final').first()"
+
+  - linkId: effective-date-time
+    text: Effective date and time
     type: dateTime
-    linkId: effective-date-time
     required: true
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
-        valueExpression:
-          language: text/fhirpath
-          expression: now()
-  - text: Height
+    initialExpression:
+      language: text/fhirpath
+      expression: now()
+
+  - linkId: height
+    text: Height
     type: quantity
-    linkId: height
-    extension:
-      - url: http://hl7.org/fhir/StructureDefinition/questionnaire-unit
-        valueCoding:
-          code: cm
-          system: http://unitsofmeasure.org
-          display: cm
-  - text: Weight
+    unitOption:
+      - code: cm
+        system: http://unitsofmeasure.org
+        display: cm
+
+  - linkId: weight
+    text: Weight
     type: quantity
-    linkId: weight
-    extension:
-      - url: http://hl7.org/fhir/StructureDefinition/questionnaire-unit
-        valueCoding:
-          code: kg
-          system: http://unitsofmeasure.org
-          display: kg
-  - text: BMI
+    unitOption:
+      - code: kg
+        system: http://unitsofmeasure.org
+        display: kg
+
+  - linkId: bmi
+    text: BMI
     type: decimal
-    linkId: bmi
     readOnly: true
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression
-        valueExpression:
-          language: text/fhirpath
-          expression: >-
-            (%QuestionnaireResponse.item.where(linkId='weight').answer.valueQuantity.value
-            /
-            ((%QuestionnaireResponse.item.where(linkId='height').answer.valueQuantity.value
-            / 100) *
-            (%QuestionnaireResponse.item.where(linkId='height').answer.valueQuantity.value
-            / 100))).round(2)
-  - text: Temperature
+    unit:
+      code: kg/m2
+      system: http://unitsofmeasure.org
+      display: kg/m2
+    calculatedExpression:
+      language: text/fhirpath
+      expression: >-
+        (%QuestionnaireResponse.item.where(linkId='weight').answer.valueQuantity.value
+        /
+        ((%QuestionnaireResponse.item.where(linkId='height').answer.valueQuantity.value
+        / 100) *
+        (%QuestionnaireResponse.item.where(linkId='height').answer.valueQuantity.value
+        / 100))).round(2)
+
+  - linkId: temperature
+    text: Temperature
     type: quantity
-    linkId: temperature
-    extension:
-      - url: http://hl7.org/fhir/StructureDefinition/questionnaire-unit
-        valueCoding:
-          code: Cel
-          system: http://unitsofmeasure.org
-          display: °C
-  - text: Oxygen saturation
+    unitOption:
+      - code: Cel
+        system: http://unitsofmeasure.org
+        display: °C
+
+  - linkId: oxygen-saturation
+    text: Oxygen saturation
     type: quantity
-    linkId: oxygen-saturation
-    extension:
-      - url: http://hl7.org/fhir/StructureDefinition/questionnaire-unit
-        valueCoding:
-          code: '%'
-          system: http://unitsofmeasure.org
-          display: '%'
-  - text: Pulse rate
+    unitOption:
+      - code: '%'
+        system: http://unitsofmeasure.org
+        display: '%'
+
+  - linkId: pulse-rate
+    text: Pulse rate
     type: quantity
-    linkId: pulse-rate
-    extension:
-      - url: http://hl7.org/fhir/StructureDefinition/questionnaire-unit
-        valueCoding:
-          code: /min
-          system: http://unitsofmeasure.org
-          display: /min
-  - text: Respiratory Rate
+    unitOption:
+      - code: /min
+        system: http://unitsofmeasure.org
+        display: /min
+
+  - linkId: respiratory-rate
+    text: Respiratory Rate
     type: quantity
-    linkId: respiratory-rate
-    extension:
-      - url: http://hl7.org/fhir/StructureDefinition/questionnaire-unit
-        valueCoding:
-          code: /min
-          system: http://unitsofmeasure.org
-          display: /min
-  - item:
-      - item:
-          - text: BP systolic
-            type: quantity
-            linkId: blood-pressure-systolic
-            extension:
-              - url: http://hl7.org/fhir/StructureDefinition/questionnaire-unit
-                valueCoding:
-                  code: mm[Hg]
-                  system: http://unitsofmeasure.org
-                  display: mmHg
-          - text: BP diastolic
-            type: quantity
-            linkId: blood-pressure-diastolic
-            extension:
-              - url: http://hl7.org/fhir/StructureDefinition/questionnaire-unit
-                valueCoding:
-                  code: mm[Hg]
-                  system: http://unitsofmeasure.org
-                  display: mmHg
+    unitOption:
+      - code: /min
+        system: http://unitsofmeasure.org
+        display: /min
+
+  - linkId: blood-pressure
+    text: Blood Pressure
+    type: group
+    item:
+      - linkId: blood-pressure-systolic-diastolic
         type: group
-        linkId: blood-pressure-systolic-diastolic
-      - text: Position
+        item:
+          - linkId: blood-pressure-systolic
+            text: BP systolic
+            type: quantity
+            unitOption:
+              - code: mm[Hg]
+                system: http://unitsofmeasure.org
+                display: mmHg
+          - linkId: blood-pressure-diastolic
+            text: BP diastolic
+            type: quantity
+            unitOption:
+              - code: mm[Hg]
+                system: http://unitsofmeasure.org
+                display: mmHg
+      - linkId: blood-pressure-position
+        text: Position
         type: choice
-        linkId: blood-pressure-position
+        itemControl:
+          coding:
+            - code: inline-choice
         answerOption:
           - valueCoding:
               system: http://snomed.info/sct
@@ -231,14 +212,12 @@ item:
               system: http://snomed.info/sct
               code: '102541000'
               display: Lying position
-        extension:
-          - url: http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl
-            valueCodeableConcept:
-              coding:
-                - code: inline-choice
-      - text: Arm
+      - linkId: blood-pressure-arm
+        text: Arm
         type: choice
-        linkId: blood-pressure-arm
+        itemControl:
+          coding:
+            - code: inline-choice
         answerOption:
           - valueCoding:
               system: http://snomed.info/sct
@@ -248,29 +227,3 @@ item:
               system: http://snomed.info/sct
               code: '368209003'
               display: Right arm
-        extension:
-          - url: http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl
-            valueCodeableConcept:
-              coding:
-                - code: inline-choice
-    text: Blood Pressure
-    type: group
-    linkId: blood-pressure
-resourceType: Questionnaire
-title: Observation create PH
-subjectType:
-  - Patient
-extension:
-  - url: https://emr-core.beda.software/StructureDefinition/questionnaire-mapper
-    valueReference:
-      reference: Mapping/observation-create-connectathon
-  - url: http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext
-    extension:
-      - url: name
-        valueCoding:
-          code: Patient
-      - url: type
-        valueCode: Patient
-status: active
-id: observation-create-connectathon
-url: observation-create

--- a/src/containers/ObservationsUberList/index.tsx
+++ b/src/containers/ObservationsUberList/index.tsx
@@ -1,25 +1,68 @@
 import { PlusOutlined } from '@ant-design/icons';
 import { t, Trans } from '@lingui/macro';
-import { Observation, ObservationComponent } from 'fhir/r4b';
+import { Observation, ObservationComponent, Quantity, Reference } from 'fhir/r4b';
 
 import { questionnaireAction, ResourceListPage } from '@beda.software/emr/components';
 import { compileAsFirst, formatHumanDateTime } from '@beda.software/emr/utils';
 
-export const getObservationCode = compileAsFirst<Observation,string>("Observation.code.coding.first().display")
+type AidboxQuantityHolder = {
+    valueQuantity?: Quantity;
+    value?: { Quantity?: Quantity };
+};
+
+function getQuantity(holder?: AidboxQuantityHolder): Quantity | undefined {
+    if (!holder) {
+        return undefined;
+    }
+    return holder.valueQuantity ?? holder.value?.Quantity;
+}
+
+function getEffectiveDateTime(resource: Observation): string | undefined {
+    return resource.effectiveDateTime ?? (resource as Observation & { effective?: { dateTime?: string } }).effective?.dateTime;
+}
+
+function getSubjectLabel(subject?: Reference): string | undefined {
+    if (!subject) {
+        return undefined;
+    }
+    if (subject.display) {
+        return subject.display;
+    }
+    if (subject.reference) {
+        return subject.reference;
+    }
+    const aidboxSubject = subject as Reference & { id?: string; resourceType?: string };
+    if (aidboxSubject.id && aidboxSubject.resourceType) {
+        return `${aidboxSubject.resourceType}/${aidboxSubject.id}`;
+    }
+    return undefined;
+}
+
+export const getObservationCode = compileAsFirst<Observation, string>('Observation.code.coding.first().display');
+
 function getComponentValue(c: ObservationComponent) {
     if (c.dataAbsentReason) {
         return [c.dataAbsentReason.text];
     }
-    return [`${c.valueQuantity?.value} ${c.valueQuantity?.unit}`];
+    const quantity = getQuantity(c);
+    return [`${quantity?.value ?? ''} ${quantity?.unit ?? ''}`.trim()];
 }
+
 export const getObservationValue = (r: Observation): string | React.ReactElement => {
     if (r.dataAbsentReason) {
         return r.dataAbsentReason.text ?? r.dataAbsentReason.coding?.[0]?.display ?? 'unknown';
-    } else if (r.valueQuantity) {
-        return `${r.valueQuantity.value} ${r.valueQuantity.unit}`;
-    } else if (r.valueCodeableConcept) {
+    }
+
+    const quantity = getQuantity(r);
+    if (quantity) {
+        return `${quantity.value} ${quantity.unit}`;
+    }
+
+    if (r.valueCodeableConcept) {
         return r.valueCodeableConcept.text ?? r.valueCodeableConcept.coding?.[0]?.display ?? 'Unknown';
-    } else if (r.component) {
+    }
+
+    if (r.component) {
         return (
             <>
                 {r.component
@@ -30,9 +73,9 @@ export const getObservationValue = (r: Observation): string | React.ReactElement
             </>
         );
     }
+
     return 'Unknown';
 };
-
 
 export function ObservationsUberList() {
     return (
@@ -52,19 +95,13 @@ export function ObservationsUberList() {
                     title: 'Date',
                     dataIndex: 'date',
                     key: 'date',
-                    render: (_text: any, { resource }) => formatHumanDateTime(resource.effectiveDateTime),
+                    render: (_text: any, { resource }) => formatHumanDateTime(getEffectiveDateTime(resource)),
                 },
                 {
                     title: 'Patient',
                     dataIndex: 'patient',
                     key: 'patient',
-                    render: (_text: any, { resource }) => {
-                        const reference = resource.subject;
-                        if (reference) {
-                            return reference.display ?? reference.reference;
-
-                        }
-                    },
+                    render: (_text: any, { resource }) => getSubjectLabel(resource.subject),
                 },
                 {
                     title: 'Code',
@@ -77,11 +114,18 @@ export function ObservationsUberList() {
                     dataIndex: 'value',
                     key: 'value',
                     render: (_text: any, { resource }) => getObservationValue(resource),
-                }
+                },
             ]}
             getHeaderActions={() => [
                 questionnaireAction(<Trans>Create observation</Trans>, 'observation-create-connectathon', {
                     icon: <PlusOutlined />,
+                    extra: {
+                        qrfProps: {
+                            launchContextParameters: [
+                                { name: 'Patient', resource: { resourceType: 'Patient' } },
+                            ],
+                        },
+                    },
                 }),
             ]}
             getReportColumns={(bundle) => [

--- a/src/containers/ObservationsUberList/index.tsx
+++ b/src/containers/ObservationsUberList/index.tsx
@@ -1,67 +1,25 @@
 import { PlusOutlined } from '@ant-design/icons';
 import { t, Trans } from '@lingui/macro';
-import { Observation, ObservationComponent, Quantity } from 'fhir/r4b';
+import { Observation } from 'fhir/r4b';
 
 import { questionnaireAction, ResourceListPage } from '@beda.software/emr/components';
 import { compileAsFirst, formatHumanDateTime } from '@beda.software/emr/utils';
 
-type AidboxQuantityHolder = {
-    valueQuantity?: Quantity;
-    value?: { Quantity?: Quantity };
-};
-
-function getQuantity(holder?: AidboxQuantityHolder): Quantity | undefined {
-    if (!holder) {
-        return undefined;
-    }
-    return holder.valueQuantity ?? holder.value?.Quantity;
-}
-
 export const getEffectiveDateTime = compileAsFirst<Observation, string>(
     'Observation.effectiveDateTime | Observation.effective.dateTime',
 );
+
 export const getSubjectLabel = compileAsFirst<Observation, string>(
-    'Observation.subject.display | Observation.subject.reference | (Observation.subject.resourceType & \'/\' & Observation.subject.id)',
+    "Observation.subject.display | Observation.subject.reference | (Observation.subject.resourceType & '/' & Observation.subject.id)",
 );
 
-export const getObservationCode = compileAsFirst<Observation, string>('Observation.code.coding.first().display');
+export const getObservationCode = compileAsFirst<Observation, string>(
+    'Observation.code.coding.first().display',
+);
 
-function getComponentValue(c: ObservationComponent) {
-    if (c.dataAbsentReason) {
-        return [c.dataAbsentReason.text];
-    }
-    const quantity = getQuantity(c);
-    return [`${quantity?.value ?? ''} ${quantity?.unit ?? ''}`.trim()];
-}
-
-export const getObservationValue = (r: Observation): string | React.ReactElement => {
-    if (r.dataAbsentReason) {
-        return r.dataAbsentReason.text ?? r.dataAbsentReason.coding?.[0]?.display ?? 'unknown';
-    }
-
-    const quantity = getQuantity(r);
-    if (quantity) {
-        return `${quantity.value} ${quantity.unit}`;
-    }
-
-    if (r.valueCodeableConcept) {
-        return r.valueCodeableConcept.text ?? r.valueCodeableConcept.coding?.[0]?.display ?? 'Unknown';
-    }
-
-    if (r.component) {
-        return (
-            <>
-                {r.component
-                    .map((c) => [...[c.code.coding?.[0]?.display], ...getComponentValue(c)].join(': '))
-                    .map((v) => (
-                        <div key={v}>{v}</div>
-                    ))}
-            </>
-        );
-    }
-
-    return 'Unknown';
-};
+export const getObservationValue = compileAsFirst<Observation, string>(
+    "Observation.dataAbsentReason.text | Observation.dataAbsentReason.coding.first().display | (Observation.valueQuantity.value.toString() + ' ' + Observation.valueQuantity.unit) | Observation.valueCodeableConcept.text | Observation.valueCodeableConcept.coding.first().display | Observation.component.select((code.coding.first().display | code.text) + ': ' + (dataAbsentReason.text | (valueQuantity.value.toString() + ' ' + valueQuantity.unit))).join(' | ') | 'Unknown'",
+);
 
 export function ObservationsUberList() {
     return (
@@ -73,9 +31,7 @@ export function ObservationsUberList() {
                     title: 'Status',
                     dataIndex: 'status',
                     key: 'status',
-                    render: (_text: any, { resource }) => {
-                        return resource.status;
-                    },
+                    render: (_text: any, { resource }) => resource.status,
                 },
                 {
                     title: 'Date',

--- a/src/containers/ObservationsUberList/index.tsx
+++ b/src/containers/ObservationsUberList/index.tsx
@@ -17,7 +17,7 @@ function getQuantity(holder?: AidboxQuantityHolder): Quantity | undefined {
     return holder.valueQuantity ?? holder.value?.Quantity;
 }
 
-function getEffectiveDateTime(resource: Observation): string | undefined {
+export function getEffectiveDateTime(resource: Observation): string | undefined {
     return resource.effectiveDateTime ?? (resource as Observation & { effective?: { dateTime?: string } }).effective?.dateTime;
 }
 

--- a/src/containers/ObservationsUberList/index.tsx
+++ b/src/containers/ObservationsUberList/index.tsx
@@ -1,6 +1,6 @@
 import { PlusOutlined } from '@ant-design/icons';
 import { t, Trans } from '@lingui/macro';
-import { Observation, ObservationComponent, Quantity, Reference } from 'fhir/r4b';
+import { Observation, ObservationComponent, Quantity } from 'fhir/r4b';
 
 import { questionnaireAction, ResourceListPage } from '@beda.software/emr/components';
 import { compileAsFirst, formatHumanDateTime } from '@beda.software/emr/utils';
@@ -17,26 +17,12 @@ function getQuantity(holder?: AidboxQuantityHolder): Quantity | undefined {
     return holder.valueQuantity ?? holder.value?.Quantity;
 }
 
-export function getEffectiveDateTime(resource: Observation): string | undefined {
-    return resource.effectiveDateTime ?? (resource as Observation & { effective?: { dateTime?: string } }).effective?.dateTime;
-}
-
-function getSubjectLabel(subject?: Reference): string | undefined {
-    if (!subject) {
-        return undefined;
-    }
-    if (subject.display) {
-        return subject.display;
-    }
-    if (subject.reference) {
-        return subject.reference;
-    }
-    const aidboxSubject = subject as Reference & { id?: string; resourceType?: string };
-    if (aidboxSubject.id && aidboxSubject.resourceType) {
-        return `${aidboxSubject.resourceType}/${aidboxSubject.id}`;
-    }
-    return undefined;
-}
+export const getEffectiveDateTime = compileAsFirst<Observation, string>(
+    'Observation.effectiveDateTime | Observation.effective.dateTime',
+);
+export const getSubjectLabel = compileAsFirst<Observation, string>(
+    'Observation.subject.display | Observation.subject.reference | (Observation.subject.resourceType & \'/\' & Observation.subject.id)',
+);
 
 export const getObservationCode = compileAsFirst<Observation, string>('Observation.code.coding.first().display');
 
@@ -101,7 +87,7 @@ export function ObservationsUberList() {
                     title: 'Patient',
                     dataIndex: 'patient',
                     key: 'patient',
-                    render: (_text: any, { resource }) => getSubjectLabel(resource.subject),
+                    render: (_text: any, { resource }) => getSubjectLabel(resource),
                 },
                 {
                     title: 'Code',


### PR DESCRIPTION
## Summary
- Migrate `observation-create-connectathon` questionnaire to FCE format (`unitOption`, `calculatedExpression`, `itemControl`).
- Flatten vitals extract mapper: remove `{% merge %}` blocks, fix `%status.code`, keep multi-resource transaction bundle.
- BP observation maps `bodySite` (arm) and `method` (position) with correct UCUM `mm[Hg]`.

## Test plan
- [x] `watch-seeds` syncs Questionnaire + Mapping (200)
- [x] `$extract` BP only with arm, position, performer — 1 Observation with components
- [x] `$extract` individual vitals (temperature, height/weight/BMI)
- [x] `$extract` full panel — 8 Observation resources
- [x] UI: Create vitals from Observations list