### PR TITLE
Fix patient Documents launch context and dashboard See all routing

### DIFF
--- a/src/containers/ObservationsUberList/index.tsx
+++ b/src/containers/ObservationsUberList/index.tsx
@@ -6,6 +6,10 @@ import { questionnaireAction, ResourceListPage } from '@beda.software/emr/compon
 import { compileAsFirst, formatHumanDateTime } from '@beda.software/emr/utils';
 
 export const getObservationCode = compileAsFirst<Observation,string>("Observation.code.coding.first().display")
+
+export function getEffectiveDateTime(resource: Observation): string | undefined {
+    return resource.effectiveDateTime ?? (resource as Observation & { effective?: { dateTime?: string } }).effective?.dateTime;
+}
 function getComponentValue(c: ObservationComponent) {
     if (c.dataAbsentReason) {
         return [c.dataAbsentReason.text];

--- a/src/containers/ObservationsUberList/index.tsx
+++ b/src/containers/ObservationsUberList/index.tsx
@@ -1,29 +1,68 @@
 import { PlusOutlined } from '@ant-design/icons';
 import { t, Trans } from '@lingui/macro';
-import { Observation, ObservationComponent } from 'fhir/r4b';
+import { Observation, ObservationComponent, Quantity, Reference } from 'fhir/r4b';
 
 import { questionnaireAction, ResourceListPage } from '@beda.software/emr/components';
 import { compileAsFirst, formatHumanDateTime } from '@beda.software/emr/utils';
 
-export const getObservationCode = compileAsFirst<Observation,string>("Observation.code.coding.first().display")
+type AidboxQuantityHolder = {
+    valueQuantity?: Quantity;
+    value?: { Quantity?: Quantity };
+};
+
+function getQuantity(holder?: AidboxQuantityHolder): Quantity | undefined {
+    if (!holder) {
+        return undefined;
+    }
+    return holder.valueQuantity ?? holder.value?.Quantity;
+}
 
 export function getEffectiveDateTime(resource: Observation): string | undefined {
     return resource.effectiveDateTime ?? (resource as Observation & { effective?: { dateTime?: string } }).effective?.dateTime;
 }
+
+function getSubjectLabel(subject?: Reference): string | undefined {
+    if (!subject) {
+        return undefined;
+    }
+    if (subject.display) {
+        return subject.display;
+    }
+    if (subject.reference) {
+        return subject.reference;
+    }
+    const aidboxSubject = subject as Reference & { id?: string; resourceType?: string };
+    if (aidboxSubject.id && aidboxSubject.resourceType) {
+        return `${aidboxSubject.resourceType}/${aidboxSubject.id}`;
+    }
+    return undefined;
+}
+
+export const getObservationCode = compileAsFirst<Observation, string>('Observation.code.coding.first().display');
+
 function getComponentValue(c: ObservationComponent) {
     if (c.dataAbsentReason) {
         return [c.dataAbsentReason.text];
     }
-    return [`${c.valueQuantity?.value} ${c.valueQuantity?.unit}`];
+    const quantity = getQuantity(c);
+    return [`${quantity?.value ?? ''} ${quantity?.unit ?? ''}`.trim()];
 }
+
 export const getObservationValue = (r: Observation): string | React.ReactElement => {
     if (r.dataAbsentReason) {
         return r.dataAbsentReason.text ?? r.dataAbsentReason.coding?.[0]?.display ?? 'unknown';
-    } else if (r.valueQuantity) {
-        return `${r.valueQuantity.value} ${r.valueQuantity.unit}`;
-    } else if (r.valueCodeableConcept) {
+    }
+
+    const quantity = getQuantity(r);
+    if (quantity) {
+        return `${quantity.value} ${quantity.unit}`;
+    }
+
+    if (r.valueCodeableConcept) {
         return r.valueCodeableConcept.text ?? r.valueCodeableConcept.coding?.[0]?.display ?? 'Unknown';
-    } else if (r.component) {
+    }
+
+    if (r.component) {
         return (
             <>
                 {r.component
@@ -34,9 +73,9 @@ export const getObservationValue = (r: Observation): string | React.ReactElement
             </>
         );
     }
+
     return 'Unknown';
 };
-
 
 export function ObservationsUberList() {
     return (
@@ -56,19 +95,13 @@ export function ObservationsUberList() {
                     title: 'Date',
                     dataIndex: 'date',
                     key: 'date',
-                    render: (_text: any, { resource }) => formatHumanDateTime(resource.effectiveDateTime),
+                    render: (_text: any, { resource }) => formatHumanDateTime(getEffectiveDateTime(resource)),
                 },
                 {
                     title: 'Patient',
                     dataIndex: 'patient',
                     key: 'patient',
-                    render: (_text: any, { resource }) => {
-                        const reference = resource.subject;
-                        if (reference) {
-                            return reference.display ?? reference.reference;
-
-                        }
-                    },
+                    render: (_text: any, { resource }) => getSubjectLabel(resource.subject),
                 },
                 {
                     title: 'Code',
@@ -81,11 +114,18 @@ export function ObservationsUberList() {
                     dataIndex: 'value',
                     key: 'value',
                     render: (_text: any, { resource }) => getObservationValue(resource),
-                }
+                },
             ]}
             getHeaderActions={() => [
                 questionnaireAction(<Trans>Create observation</Trans>, 'observation-create-connectathon', {
                     icon: <PlusOutlined />,
+                    extra: {
+                        qrfProps: {
+                            launchContextParameters: [
+                                { name: 'Patient', resource: { resourceType: 'Patient' } },
+                            ],
+                        },
+                    },
                 }),
             ]}
             getReportColumns={(bundle) => [

--- a/src/containers/PatientsUberList/PatientOverviewResources.tsx
+++ b/src/containers/PatientsUberList/PatientOverviewResources.tsx
@@ -1,0 +1,147 @@
+import { Composition, Encounter, Observation, Patient, Procedure } from 'fhir/r4b';
+
+import { ResourceTable } from '@beda.software/emr/dist/components/ResourceTable/index';
+import { PatientResources } from '@beda.software/emr/dist/containers/PatientDetails/PatientResources/index';
+import { formatHumanDateTime, formatPeriodDateTime } from '@beda.software/emr/utils';
+import { WithId } from '@beda.software/fhir-react';
+
+import { getOrganization, getPractitioner } from '../EncountersUberList';
+import { getObservationCode, getObservationValue, getEffectiveDateTime } from '../ObservationsUberList';
+
+const patientResourcesTypes = new Set(['immunization', 'conditions', 'allergies', 'consents', 'serviceRequests', 'active-medications']);
+
+interface Props {
+    patient: WithId<Patient>;
+    type?: string;
+}
+
+function ObservationsTable({ patient }: { patient: WithId<Patient> }) {
+    return (
+        <ResourceTable<Observation>
+            resourceType="Observation"
+            params={{
+                patient: patient.id,
+                _sort: '-_lastUpdated',
+            }}
+            getTableColumns={() => [
+                {
+                    title: 'Status',
+                    key: 'status',
+                    render: (resource) => resource.status,
+                },
+                {
+                    title: 'Date',
+                    key: 'date',
+                    render: (resource) => formatHumanDateTime(getEffectiveDateTime(resource)),
+                },
+                {
+                    title: 'Code',
+                    key: 'code',
+                    render: (resource) => getObservationCode(resource),
+                },
+                {
+                    title: 'Value',
+                    key: 'value',
+                    render: (resource) => getObservationValue(resource),
+                },
+            ]}
+        />
+    );
+}
+
+export function PatientOverviewResources({ patient, type }: Props) {
+    if (type === 'observations' || type === 'observation') {
+        return <ObservationsTable patient={patient} />;
+    }
+
+    if (!type || patientResourcesTypes.has(type)) {
+        return <PatientResources patient={patient} />;
+    }
+
+    switch (type) {
+        case 'encounters':
+            return (
+                <ResourceTable<Encounter>
+                    resourceType="Encounter"
+                    params={{
+                        patient: patient.id,
+                        _sort: '-_lastUpdated',
+                    }}
+                    getTableColumns={() => [
+                        {
+                            title: 'Status',
+                            key: 'status',
+                            render: (resource) => resource.status,
+                        },
+                        {
+                            title: 'Date',
+                            key: 'date',
+                            render: (resource) => formatPeriodDateTime(resource.period),
+                        },
+                        {
+                            title: 'Practitioner',
+                            key: 'practitioner',
+                            render: (resource) => {
+                                const reference = getPractitioner(resource);
+                                return reference?.display ?? reference?.reference;
+                            },
+                        },
+                        {
+                            title: 'Organization',
+                            key: 'organization',
+                            render: (resource) => {
+                                const reference = getOrganization(resource);
+                                return reference?.display ?? reference?.reference;
+                            },
+                        },
+                    ]}
+                />
+            );
+        case 'procedures':
+            return (
+                <ResourceTable<Procedure>
+                    resourceType="Procedure"
+                    params={{
+                        subject: patient.id,
+                        _sort: '-_lastUpdated',
+                    }}
+                    getTableColumns={() => [
+                        {
+                            title: 'Status',
+                            key: 'status',
+                            render: (resource) => resource.status,
+                        },
+                        {
+                            title: 'Code',
+                            key: 'code',
+                            render: (resource) => resource.code?.text ?? resource.code?.coding?.[0]?.display,
+                        },
+                    ]}
+                />
+            );
+        case 'composition':
+            return (
+                <ResourceTable<Composition>
+                    resourceType="Composition"
+                    params={{
+                        subject: patient.id,
+                        _sort: '-date',
+                    }}
+                    getTableColumns={() => [
+                        {
+                            title: 'Title',
+                            key: 'title',
+                            render: (resource) => resource.title,
+                        },
+                        {
+                            title: 'Date',
+                            key: 'date',
+                            render: (resource) => resource.date,
+                        },
+                    ]}
+                />
+            );
+        default:
+            return <ObservationsTable patient={patient} />;
+    }
+}

--- a/src/containers/PatientsUberList/connectathonDocumentLaunchContext.ts
+++ b/src/containers/PatientsUberList/connectathonDocumentLaunchContext.ts
@@ -1,0 +1,18 @@
+import type { ParametersParameter, Patient } from 'fhir/r4b';
+
+import { getReference, WithId } from '@beda.software/fhir-react';
+
+export function connectathonDocumentLaunchContext(patient: WithId<Patient>): ParametersParameter[] {
+    const patientRef = getReference(patient);
+
+    return [
+        { name: 'patient', resource: patient },
+        { name: 'Patient', resource: patient },
+        { name: 'Condition', resource: { resourceType: 'Condition', subject: patientRef } },
+        { name: 'MedicationStatement', resource: { resourceType: 'MedicationStatement', subject: patientRef } },
+        { name: 'Procedure', resource: { resourceType: 'Procedure', subject: patientRef } },
+        { name: 'Encounter', resource: { resourceType: 'Encounter', subject: patientRef } },
+        { name: 'Observation', resource: { resourceType: 'Observation', subject: patientRef } },
+        { name: 'Immunization', resource: { resourceType: 'Immunization', patient: patientRef } },
+    ];
+}

--- a/src/containers/PatientsUberList/dashboard.tsx
+++ b/src/containers/PatientsUberList/dashboard.tsx
@@ -22,7 +22,7 @@ import { formatHumanDateTime, formatPeriodDateTime } from '@beda.software/emr/ut
 import { prepareIPSBundle } from './utils';
 import { getOrganization, getPractitioner } from '../EncountersUberList';
 import { getPerformers } from '../ImmunizationsUberList ';
-import { getObservationCode, getObservationValue } from '../ObservationsUberList';
+import { getObservationCode, getObservationValue, getEffectiveDateTime } from '../ObservationsUberList';
 
 function prepareComposition(
     resources: Composition[],
@@ -75,7 +75,7 @@ function prepareComposition(
 function prepareEncounter(resources: Encounter[], bundle: Bundle<Encounter>): OverviewCard<Encounter> {
     return {
         title: 'Encounters',
-        key: 'ecnounter',
+        key: 'encounters',
         icon: <h2></h2>,
         data: resources,
         total: bundle.total ?? 0,
@@ -161,7 +161,7 @@ function prepareImmunization(resources: Immunization[], bundle: Bundle<Immunizat
 function prepareObservation(resources: Observation[], bundle: Bundle<Observation>): OverviewCard<Observation> {
     return {
         title: 'Observation',
-        key: 'observation',
+        key: 'observations',
         icon: <h2></h2>,
         data: resources,
         total: bundle.total ?? 0,
@@ -177,7 +177,7 @@ function prepareObservation(resources: Observation[], bundle: Bundle<Observation
             {
                 title: 'Date',
                 key: 'date',
-                render: (resource) => formatHumanDateTime(resource.effectiveDateTime),
+                render: (resource) => formatHumanDateTime(getEffectiveDateTime(resource)),
             },
             {
                 title: 'Code',
@@ -196,7 +196,7 @@ function prepareObservation(resources: Observation[], bundle: Bundle<Observation
 function prepareProcedure(resources: Procedure[], bundle: Bundle<Procedure>): OverviewCard<Procedure> {
     return {
         title: 'Procedure',
-        key: 'procedure',
+        key: 'procedures',
         icon: <h2></h2>,
         data: resources,
         total: bundle.total ?? 0,

--- a/src/containers/PatientsUberList/dashboard.tsx
+++ b/src/containers/PatientsUberList/dashboard.tsx
@@ -17,12 +17,22 @@ import {
 import type { Dashboard, DashboardInstance } from '@beda.software/emr/dist/components/Dashboard/types';
 import type { OverviewCard } from '@beda.software/emr/dist/containers/PatientDetails/PatientOverviewDynamic/components/StandardCard/types';
 import { StandardCardContainerFabric } from '@beda.software/emr/dist/containers/PatientDetails/PatientOverviewDynamic/containers/StandardCardContainerFabric/index';
-import { formatHumanDateTime, formatPeriodDateTime } from '@beda.software/emr/utils';
+import { formatHumanDateTime, formatPeriodDateTime, compileAsFirst } from '@beda.software/emr/utils';
 
 import { prepareIPSBundle } from './utils';
-import { getOrganization, getPractitioner } from '../EncountersUberList';
 import { getPerformers } from '../ImmunizationsUberList ';
 import { getObservationCode, getObservationValue, getEffectiveDateTime } from '../ObservationsUberList';
+import { getProcedureCode } from '../ProceduresUberList';
+
+const getVaccineCode = compileAsFirst<Immunization, string>(
+    'Immunization.vaccineCode.text | Immunization.vaccineCode.coding.first().display',
+);
+const getPractitionerLabel = compileAsFirst<Encounter, string>(
+    'Encounter.participant.individual.display | Encounter.participant.individual.reference',
+);
+const getOrganizationLabel = compileAsFirst<Encounter, string>(
+    'Encounter.serviceProvider.display | Encounter.serviceProvider.reference',
+);
 
 function prepareComposition(
     resources: Composition[],
@@ -97,22 +107,12 @@ function prepareEncounter(resources: Encounter[], bundle: Bundle<Encounter>): Ov
             {
                 title: 'Practitioner',
                 key: 'practitioner',
-                render: (resource) => {
-                    const reference = getPractitioner(resource);
-                    if (reference) {
-                        return reference.display ?? reference.reference;
-                    }
-                },
+                render: (resource) => getPractitionerLabel(resource),
             },
             {
                 title: 'Organization',
                 key: 'organization',
-                render: (resource) => {
-                    const reference = getOrganization(resource);
-                    if (reference) {
-                        return reference.display ?? reference.reference;
-                    }
-                },
+                render: (resource) => getOrganizationLabel(resource),
             },
         ],
     };
@@ -144,7 +144,7 @@ function prepareImmunization(resources: Immunization[], bundle: Bundle<Immunizat
                 title: 'Vaccine',
                 key: 'vaccine',
                 width: 250,
-                render: (resource) => resource.vaccineCode.text,
+                render: (resource) => getVaccineCode(resource),
             },
             {
                 title: 'Performer',
@@ -212,9 +212,7 @@ function prepareProcedure(resources: Procedure[], bundle: Bundle<Procedure>): Ov
             {
                 title: 'Code',
                 key: 'code',
-                render: (resource) => {
-                    return resource.code?.text ?? resource.code?.coding?.[0]?.display;
-                },
+                render: (resource) => getProcedureCode(resource),
             },
         ],
     };

--- a/src/containers/PatientsUberList/detail.tsx
+++ b/src/containers/PatientsUberList/detail.tsx
@@ -1,156 +1,110 @@
 import { Bundle, Parameters, Patient, Questionnaire, QuestionnaireResponse } from 'fhir/r4b';
-import { Link, Route, Routes, useParams } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 
-import { PageContainer } from '@beda.software/emr/dist/components/BaseLayout/PageContainer/index';
-import { RenderBundleResourceContext } from '@beda.software/emr/dist/components/RenderBundleResourceContext/index';
-import { Tabs } from '@beda.software/emr/dist/components/Tabs/index';
 import { PatientDashboardProvider } from '@beda.software/emr/dist/components/Dashboard/contexts';
 import { PatientDocument } from '@beda.software/emr/dist/containers/PatientDetails/PatientDocument/index';
 import { PatientDocumentDetails } from '@beda.software/emr/dist/containers/PatientDetails/PatientDocumentDetails/index';
 import { PatientDocuments } from '@beda.software/emr/dist/containers/PatientDetails/PatientDocuments/index';
 import { PatientOverview } from '@beda.software/emr/dist/containers/PatientDetails/PatientOverviewDynamic/index';
+import { ResourceDetailPage, Tab } from '@beda.software/emr/dist/uberComponents/ResourceDetailPage/index';
 import { compileAsFirst, selectCurrentUserRoleResource } from '@beda.software/emr/dist/utils/index';
 import { WithId, extractBundleResources } from '@beda.software/fhir-react';
 import { isFailure, isSuccess, mapSuccess } from '@beda.software/remote-data';
 
 import { dashboard } from './dashboard';
 import { patientDocumentLaunchContext } from './patientDocumentLaunchContext';
-import { PatientOverviewResources } from './PatientOverviewResources';
 import { getFHIRResources, service } from '@beda.software/emr/services';
 
 const getName = compileAsFirst<Patient, string>("Patient.name.given.first() + ' ' + Patient.name.family");
 
-function PatientDetailsTabs({ patientId, splat }: { patientId: string; splat: string }) {
-    const basePath = `/patients-ph/${patientId}`;
-    const activeKey = splat.startsWith('documents')
-        ? 'documents'
-        : splat.startsWith('resources/')
-          ? 'overview'
-          : 'overview';
-
-    return (
-        <Tabs
-            type="card"
-            boxShadow={false}
-            activeKey={activeKey}
-            items={[
-                { key: 'overview', label: <Link to={basePath}>Overview</Link> },
-                { key: 'documents', label: <Link to={`${basePath}/documents`}>Documents</Link> },
-            ]}
-        />
-    );
-}
-
-function PatientDetailsContent({ resource, bundle }: { resource: WithId<Patient>; bundle: Bundle }) {
-    const splat = useParams()['*'] ?? '';
-
-    const content = (() => {
-        if (splat.startsWith('resources/')) {
-            const type = splat.slice('resources/'.length).split('/')[0];
-            return <PatientOverviewResources patient={resource} type={type} />;
-        }
-        if (splat.startsWith('documents')) {
-            return <Documents patient={resource} splat={splat} />;
-        }
-        return <PatientOverview patient={resource} />;
-    })();
-
-    return (
-        <PageContainer
-            title={getName(resource, { bundle })!}
-            layoutVariant="with-tabs"
-            headerContent={<PatientDetailsTabs patientId={resource.id} splat={splat} />}
-        >
-            {content}
-        </PageContainer>
-    );
-}
+const tabs: Array<Tab<WithId<Patient>>> = [
+    {
+        path: '',
+        label: 'Overview',
+        component: ({ resource }) => <PatientOverview patient={resource} />,
+    },
+    {
+        path: 'documents',
+        label: 'Documents',
+        component: ({ resource }) => <Documents patient={resource} />,
+    },
+];
 
 const getResult = compileAsFirst<Parameters, Bundle>("Parameters.parameter.where(name='return').resource");
 
-async function sdcExtact(qr: QuestionnaireResponse) {
+async function sdcExtact(qr: QuestionnaireResponse){
     const questionnaire = mapSuccess(
         await getFHIRResources<Questionnaire>('Questionnaire', { url: qr.questionnaire }),
-        (bundle) => extractBundleResources(bundle).Questionnaire[0]!,
+        (bundle) => extractBundleResources(bundle).Questionnaire[0]!
     );
     if (isFailure(questionnaire)) {
-        console.log('ERROR', questionnaire.error);
+        console.log("ERROR", questionnaire.error)
         return;
     }
     const extractParameters: Parameters = {
         resourceType: 'Parameters',
         parameter: [
             { name: 'questionnaire', resource: questionnaire.data },
-            { name: 'questionnaire-response', resource: qr },
-        ],
-    };
+            { name: 'questionnaire-response', resource: qr},
+        ]
+    }
     const sdcExtractResult = await service({
         url: 'QuestionnaireResponse/$extract',
         method: 'POST',
-        data: extractParameters,
+        data: extractParameters
     });
-    if (isSuccess(sdcExtractResult)) {
+    if (isSuccess(sdcExtractResult)){
         const bundle = getResult(sdcExtractResult.data);
         const transactionResult = await service({
             url: '/',
             method: 'POST',
             data: bundle,
-        });
+        })
         console.log(transactionResult);
     }
 }
 
-function Documents({ patient, splat }: { patient: WithId<Patient>; splat: string }) {
+function Documents({ patient }: { patient: WithId<Patient> }) {
     const author = selectCurrentUserRoleResource();
-    const rest = splat === 'documents' ? '' : splat.slice('documents/'.length);
-
-    if (rest.startsWith('new/')) {
-        const questionnaireId = rest.split('/')[1]!;
-        return (
-            <PatientDocument
-                patient={patient}
-                author={author}
-                questionnaireId={questionnaireId}
-                autoSave={true}
-                onSuccess={async (result) => {
-                    await sdcExtact(result.questionnaireResponse);
-                    window.history.back();
-                }}
-                launchContextParameters={patientDocumentLaunchContext(patient)}
+    return (
+        <Routes>
+            <Route path="/" element={<PatientDocuments patient={patient} />} />
+            <Route
+                path="/new/:questionnaireId"
+                element={
+                    <PatientDocument
+                        patient={patient}
+                        author={author}
+                        autoSave={true}
+                        onSuccess={async (result) => {
+                            await sdcExtact(result.questionnaireResponse);
+                            window.history.back();
+                        }}
+                        launchContextParameters={patientDocumentLaunchContext(patient)}
+                    />
+                }
             />
-        );
-    }
-
-    if (rest && !rest.startsWith('new/')) {
-        return (
-            <Routes>
-                <Route
-                    path="/patients-ph/:id/documents/:qrId/*"
-                    element={
-                        <PatientDocumentDetails
-                            patient={patient}
-                            launchContextParameters={patientDocumentLaunchContext(patient)}
-                        />
-                    }
-                />
-            </Routes>
-        );
-    }
-
-    return <PatientDocuments patient={patient} />;
+            <Route
+                path="/:qrId/*"
+                element={
+                    <PatientDocumentDetails
+                        patient={patient}
+                        launchContextParameters={patientDocumentLaunchContext(patient)}/>
+                }
+            />
+        </Routes>
+    );
 }
 
 export function PatientDetails() {
     return (
         <PatientDashboardProvider dashboard={dashboard}>
-            <RenderBundleResourceContext<Patient>
+            <ResourceDetailPage<Patient>
                 resourceType="Patient"
                 getSearchParams={({ id }) => ({ _id: id })}
                 getTitle={({ resource, bundle }) => getName(resource, { bundle })!}
-                tabs={[]}
-            >
-                {(context) => <PatientDetailsContent resource={context.resource} bundle={context.bundle} />}
-            </RenderBundleResourceContext>
+                tabs={tabs}
+            />
         </PatientDashboardProvider>
     );
 }

--- a/src/containers/PatientsUberList/detail.tsx
+++ b/src/containers/PatientsUberList/detail.tsx
@@ -1,109 +1,156 @@
 import { Bundle, Parameters, Patient, Questionnaire, QuestionnaireResponse } from 'fhir/r4b';
-import { Route, Routes } from 'react-router-dom';
+import { Link, Route, Routes, useParams } from 'react-router-dom';
 
+import { PageContainer } from '@beda.software/emr/dist/components/BaseLayout/PageContainer/index';
+import { RenderBundleResourceContext } from '@beda.software/emr/dist/components/RenderBundleResourceContext/index';
+import { Tabs } from '@beda.software/emr/dist/components/Tabs/index';
 import { PatientDashboardProvider } from '@beda.software/emr/dist/components/Dashboard/contexts';
 import { PatientDocument } from '@beda.software/emr/dist/containers/PatientDetails/PatientDocument/index';
 import { PatientDocumentDetails } from '@beda.software/emr/dist/containers/PatientDetails/PatientDocumentDetails/index';
 import { PatientDocuments } from '@beda.software/emr/dist/containers/PatientDetails/PatientDocuments/index';
 import { PatientOverview } from '@beda.software/emr/dist/containers/PatientDetails/PatientOverviewDynamic/index';
-import { ResourceDetailPage, Tab } from '@beda.software/emr/dist/uberComponents/ResourceDetailPage/index';
 import { compileAsFirst, selectCurrentUserRoleResource } from '@beda.software/emr/dist/utils/index';
 import { WithId, extractBundleResources } from '@beda.software/fhir-react';
 import { isFailure, isSuccess, mapSuccess } from '@beda.software/remote-data';
 
 import { dashboard } from './dashboard';
+import { patientDocumentLaunchContext } from './patientDocumentLaunchContext';
+import { PatientOverviewResources } from './PatientOverviewResources';
 import { getFHIRResources, service } from '@beda.software/emr/services';
 
 const getName = compileAsFirst<Patient, string>("Patient.name.given.first() + ' ' + Patient.name.family");
 
-const tabs: Array<Tab<WithId<Patient>>> = [
-    {
-        path: '',
-        label: 'Overview',
-        component: ({ resource }) => <PatientOverview patient={resource} />,
-    },
-    {
-        path: 'documents',
-        label: 'Documents',
-        component: ({ resource }) => <Documents patient={resource} />,
-    },
-];
+function PatientDetailsTabs({ patientId, splat }: { patientId: string; splat: string }) {
+    const basePath = `/patients-ph/${patientId}`;
+    const activeKey = splat.startsWith('documents')
+        ? 'documents'
+        : splat.startsWith('resources/')
+          ? 'overview'
+          : 'overview';
+
+    return (
+        <Tabs
+            type="card"
+            boxShadow={false}
+            activeKey={activeKey}
+            items={[
+                { key: 'overview', label: <Link to={basePath}>Overview</Link> },
+                { key: 'documents', label: <Link to={`${basePath}/documents`}>Documents</Link> },
+            ]}
+        />
+    );
+}
+
+function PatientDetailsContent({ resource, bundle }: { resource: WithId<Patient>; bundle: Bundle }) {
+    const splat = useParams()['*'] ?? '';
+
+    const content = (() => {
+        if (splat.startsWith('resources/')) {
+            const type = splat.slice('resources/'.length).split('/')[0];
+            return <PatientOverviewResources patient={resource} type={type} />;
+        }
+        if (splat.startsWith('documents')) {
+            return <Documents patient={resource} splat={splat} />;
+        }
+        return <PatientOverview patient={resource} />;
+    })();
+
+    return (
+        <PageContainer
+            title={getName(resource, { bundle })!}
+            layoutVariant="with-tabs"
+            headerContent={<PatientDetailsTabs patientId={resource.id} splat={splat} />}
+        >
+            {content}
+        </PageContainer>
+    );
+}
 
 const getResult = compileAsFirst<Parameters, Bundle>("Parameters.parameter.where(name='return').resource");
 
-async function sdcExtact(qr: QuestionnaireResponse){
+async function sdcExtact(qr: QuestionnaireResponse) {
     const questionnaire = mapSuccess(
         await getFHIRResources<Questionnaire>('Questionnaire', { url: qr.questionnaire }),
-        (bundle) => extractBundleResources(bundle).Questionnaire[0]!
+        (bundle) => extractBundleResources(bundle).Questionnaire[0]!,
     );
     if (isFailure(questionnaire)) {
-        console.log("ERROR", questionnaire.error)
+        console.log('ERROR', questionnaire.error);
         return;
     }
     const extractParameters: Parameters = {
         resourceType: 'Parameters',
         parameter: [
             { name: 'questionnaire', resource: questionnaire.data },
-            { name: 'questionnaire-response', resource: qr},
-        ]
-    }
+            { name: 'questionnaire-response', resource: qr },
+        ],
+    };
     const sdcExtractResult = await service({
         url: 'QuestionnaireResponse/$extract',
         method: 'POST',
-        data: extractParameters
+        data: extractParameters,
     });
-    if (isSuccess(sdcExtractResult)){
+    if (isSuccess(sdcExtractResult)) {
         const bundle = getResult(sdcExtractResult.data);
         const transactionResult = await service({
             url: '/',
             method: 'POST',
             data: bundle,
-        })
+        });
         console.log(transactionResult);
     }
 }
 
-function Documents({ patient }: { patient: WithId<Patient> }) {
+function Documents({ patient, splat }: { patient: WithId<Patient>; splat: string }) {
     const author = selectCurrentUserRoleResource();
-    return (
-        <Routes>
-            <Route path="/" element={<PatientDocuments patient={patient} />} />
-            <Route
-                path="/new/:questionnaireId"
-                element={
-                    <PatientDocument
-                        patient={patient}
-                        author={author}
-                        autoSave={true}
-                        onSuccess={async (result) => {
-                            await sdcExtact(result.questionnaireResponse);
-                            window.history.back();
-                        }}
-                        launchContextParameters={[{'name': 'patient', resource: patient}]}
-                    />
-                }
+    const rest = splat === 'documents' ? '' : splat.slice('documents/'.length);
+
+    if (rest.startsWith('new/')) {
+        const questionnaireId = rest.split('/')[1]!;
+        return (
+            <PatientDocument
+                patient={patient}
+                author={author}
+                questionnaireId={questionnaireId}
+                autoSave={true}
+                onSuccess={async (result) => {
+                    await sdcExtact(result.questionnaireResponse);
+                    window.history.back();
+                }}
+                launchContextParameters={patientDocumentLaunchContext(patient)}
             />
-            <Route
-                path="/:qrId/*"
-                element={
-                    <PatientDocumentDetails
-                        patient={patient}
-                        launchContextParameters={[{ 'name': 'patient', resource: patient }]}/>
-                }
-            />
-        </Routes>
-    );
+        );
+    }
+
+    if (rest && !rest.startsWith('new/')) {
+        return (
+            <Routes>
+                <Route
+                    path="/patients-ph/:id/documents/:qrId/*"
+                    element={
+                        <PatientDocumentDetails
+                            patient={patient}
+                            launchContextParameters={patientDocumentLaunchContext(patient)}
+                        />
+                    }
+                />
+            </Routes>
+        );
+    }
+
+    return <PatientDocuments patient={patient} />;
 }
 
 export function PatientDetails() {
     return (
         <PatientDashboardProvider dashboard={dashboard}>
-            <ResourceDetailPage<Patient>
+            <RenderBundleResourceContext<Patient>
                 resourceType="Patient"
                 getSearchParams={({ id }) => ({ _id: id })}
                 getTitle={({ resource, bundle }) => getName(resource, { bundle })!}
-                tabs={tabs}
-            />
+                tabs={[]}
+            >
+                {(context) => <PatientDetailsContent resource={context.resource} bundle={context.bundle} />}
+            </RenderBundleResourceContext>
         </PatientDashboardProvider>
     );
 }

--- a/src/containers/PatientsUberList/detail.tsx
+++ b/src/containers/PatientsUberList/detail.tsx
@@ -1,110 +1,156 @@
 import { Bundle, Parameters, Patient, Questionnaire, QuestionnaireResponse } from 'fhir/r4b';
-import { Route, Routes } from 'react-router-dom';
+import { Link, Route, Routes, useParams } from 'react-router-dom';
 
+import { PageContainer } from '@beda.software/emr/dist/components/BaseLayout/PageContainer/index';
+import { RenderBundleResourceContext } from '@beda.software/emr/dist/components/RenderBundleResourceContext/index';
+import { Tabs } from '@beda.software/emr/dist/components/Tabs/index';
 import { PatientDashboardProvider } from '@beda.software/emr/dist/components/Dashboard/contexts';
 import { PatientDocument } from '@beda.software/emr/dist/containers/PatientDetails/PatientDocument/index';
 import { PatientDocumentDetails } from '@beda.software/emr/dist/containers/PatientDetails/PatientDocumentDetails/index';
 import { PatientDocuments } from '@beda.software/emr/dist/containers/PatientDetails/PatientDocuments/index';
 import { PatientOverview } from '@beda.software/emr/dist/containers/PatientDetails/PatientOverviewDynamic/index';
-import { ResourceDetailPage, Tab } from '@beda.software/emr/dist/uberComponents/ResourceDetailPage/index';
 import { compileAsFirst, selectCurrentUserRoleResource } from '@beda.software/emr/dist/utils/index';
 import { WithId, extractBundleResources } from '@beda.software/fhir-react';
 import { isFailure, isSuccess, mapSuccess } from '@beda.software/remote-data';
 
 import { dashboard } from './dashboard';
 import { patientDocumentLaunchContext } from './patientDocumentLaunchContext';
+import { PatientOverviewResources } from './PatientOverviewResources';
 import { getFHIRResources, service } from '@beda.software/emr/services';
 
 const getName = compileAsFirst<Patient, string>("Patient.name.given.first() + ' ' + Patient.name.family");
 
-const tabs: Array<Tab<WithId<Patient>>> = [
-    {
-        path: '',
-        label: 'Overview',
-        component: ({ resource }) => <PatientOverview patient={resource} />,
-    },
-    {
-        path: 'documents',
-        label: 'Documents',
-        component: ({ resource }) => <Documents patient={resource} />,
-    },
-];
+function PatientDetailsTabs({ patientId, splat }: { patientId: string; splat: string }) {
+    const basePath = `/patients-ph/${patientId}`;
+    const activeKey = splat.startsWith('documents')
+        ? 'documents'
+        : splat.startsWith('resources/')
+          ? 'overview'
+          : 'overview';
+
+    return (
+        <Tabs
+            type="card"
+            boxShadow={false}
+            activeKey={activeKey}
+            items={[
+                { key: 'overview', label: <Link to={basePath}>Overview</Link> },
+                { key: 'documents', label: <Link to={`${basePath}/documents`}>Documents</Link> },
+            ]}
+        />
+    );
+}
+
+function PatientDetailsContent({ resource, bundle }: { resource: WithId<Patient>; bundle: Bundle }) {
+    const splat = useParams()['*'] ?? '';
+
+    const content = (() => {
+        if (splat.startsWith('resources/')) {
+            const type = splat.slice('resources/'.length).split('/')[0];
+            return <PatientOverviewResources patient={resource} type={type} />;
+        }
+        if (splat.startsWith('documents')) {
+            return <Documents patient={resource} splat={splat} />;
+        }
+        return <PatientOverview patient={resource} />;
+    })();
+
+    return (
+        <PageContainer
+            title={getName(resource, { bundle })!}
+            layoutVariant="with-tabs"
+            headerContent={<PatientDetailsTabs patientId={resource.id} splat={splat} />}
+        >
+            {content}
+        </PageContainer>
+    );
+}
 
 const getResult = compileAsFirst<Parameters, Bundle>("Parameters.parameter.where(name='return').resource");
 
-async function sdcExtact(qr: QuestionnaireResponse){
+async function sdcExtact(qr: QuestionnaireResponse) {
     const questionnaire = mapSuccess(
         await getFHIRResources<Questionnaire>('Questionnaire', { url: qr.questionnaire }),
-        (bundle) => extractBundleResources(bundle).Questionnaire[0]!
+        (bundle) => extractBundleResources(bundle).Questionnaire[0]!,
     );
     if (isFailure(questionnaire)) {
-        console.log("ERROR", questionnaire.error)
+        console.log('ERROR', questionnaire.error);
         return;
     }
     const extractParameters: Parameters = {
         resourceType: 'Parameters',
         parameter: [
             { name: 'questionnaire', resource: questionnaire.data },
-            { name: 'questionnaire-response', resource: qr},
-        ]
-    }
+            { name: 'questionnaire-response', resource: qr },
+        ],
+    };
     const sdcExtractResult = await service({
         url: 'QuestionnaireResponse/$extract',
         method: 'POST',
-        data: extractParameters
+        data: extractParameters,
     });
-    if (isSuccess(sdcExtractResult)){
+    if (isSuccess(sdcExtractResult)) {
         const bundle = getResult(sdcExtractResult.data);
         const transactionResult = await service({
             url: '/',
             method: 'POST',
             data: bundle,
-        })
+        });
         console.log(transactionResult);
     }
 }
 
-function Documents({ patient }: { patient: WithId<Patient> }) {
+function Documents({ patient, splat }: { patient: WithId<Patient>; splat: string }) {
     const author = selectCurrentUserRoleResource();
-    return (
-        <Routes>
-            <Route path="/" element={<PatientDocuments patient={patient} />} />
-            <Route
-                path="/new/:questionnaireId"
-                element={
-                    <PatientDocument
-                        patient={patient}
-                        author={author}
-                        autoSave={true}
-                        onSuccess={async (result) => {
-                            await sdcExtact(result.questionnaireResponse);
-                            window.history.back();
-                        }}
-                        launchContextParameters={patientDocumentLaunchContext(patient)}
-                    />
-                }
+    const rest = splat === 'documents' ? '' : splat.slice('documents/'.length);
+
+    if (rest.startsWith('new/')) {
+        const questionnaireId = rest.split('/')[1]!;
+        return (
+            <PatientDocument
+                patient={patient}
+                author={author}
+                questionnaireId={questionnaireId}
+                autoSave={true}
+                onSuccess={async (result) => {
+                    await sdcExtact(result.questionnaireResponse);
+                    window.history.back();
+                }}
+                launchContextParameters={patientDocumentLaunchContext(patient)}
             />
-            <Route
-                path="/:qrId/*"
-                element={
-                    <PatientDocumentDetails
-                        patient={patient}
-                        launchContextParameters={patientDocumentLaunchContext(patient)}/>
-                }
-            />
-        </Routes>
-    );
+        );
+    }
+
+    if (rest && !rest.startsWith('new/')) {
+        return (
+            <Routes>
+                <Route
+                    path="/patients-ph/:id/documents/:qrId/*"
+                    element={
+                        <PatientDocumentDetails
+                            patient={patient}
+                            launchContextParameters={patientDocumentLaunchContext(patient)}
+                        />
+                    }
+                />
+            </Routes>
+        );
+    }
+
+    return <PatientDocuments patient={patient} />;
 }
 
 export function PatientDetails() {
     return (
         <PatientDashboardProvider dashboard={dashboard}>
-            <ResourceDetailPage<Patient>
+            <RenderBundleResourceContext<Patient>
                 resourceType="Patient"
                 getSearchParams={({ id }) => ({ _id: id })}
                 getTitle={({ resource, bundle }) => getName(resource, { bundle })!}
-                tabs={tabs}
-            />
+                tabs={[]}
+            >
+                {(context) => <PatientDetailsContent resource={context.resource} bundle={context.bundle} />}
+            </RenderBundleResourceContext>
         </PatientDashboardProvider>
     );
 }

--- a/src/containers/PatientsUberList/detail.tsx
+++ b/src/containers/PatientsUberList/detail.tsx
@@ -12,7 +12,7 @@ import { WithId, extractBundleResources } from '@beda.software/fhir-react';
 import { isFailure, isSuccess, mapSuccess } from '@beda.software/remote-data';
 
 import { dashboard } from './dashboard';
-import { connectathonDocumentLaunchContext } from './connectathonDocumentLaunchContext';
+import { patientDocumentLaunchContext } from './patientDocumentLaunchContext';
 import { getFHIRResources, service } from '@beda.software/emr/services';
 
 const getName = compileAsFirst<Patient, string>("Patient.name.given.first() + ' ' + Patient.name.family");
@@ -80,7 +80,7 @@ function Documents({ patient }: { patient: WithId<Patient> }) {
                             await sdcExtact(result.questionnaireResponse);
                             window.history.back();
                         }}
-                        launchContextParameters={connectathonDocumentLaunchContext(patient)}
+                        launchContextParameters={patientDocumentLaunchContext(patient)}
                     />
                 }
             />
@@ -89,7 +89,7 @@ function Documents({ patient }: { patient: WithId<Patient> }) {
                 element={
                     <PatientDocumentDetails
                         patient={patient}
-                        launchContextParameters={connectathonDocumentLaunchContext(patient)}/>
+                        launchContextParameters={patientDocumentLaunchContext(patient)}/>
                 }
             />
         </Routes>

--- a/src/containers/PatientsUberList/detail.tsx
+++ b/src/containers/PatientsUberList/detail.tsx
@@ -12,6 +12,7 @@ import { WithId, extractBundleResources } from '@beda.software/fhir-react';
 import { isFailure, isSuccess, mapSuccess } from '@beda.software/remote-data';
 
 import { dashboard } from './dashboard';
+import { connectathonDocumentLaunchContext } from './connectathonDocumentLaunchContext';
 import { getFHIRResources, service } from '@beda.software/emr/services';
 
 const getName = compileAsFirst<Patient, string>("Patient.name.given.first() + ' ' + Patient.name.family");
@@ -79,7 +80,7 @@ function Documents({ patient }: { patient: WithId<Patient> }) {
                             await sdcExtact(result.questionnaireResponse);
                             window.history.back();
                         }}
-                        launchContextParameters={[{'name': 'patient', resource: patient}]}
+                        launchContextParameters={connectathonDocumentLaunchContext(patient)}
                     />
                 }
             />
@@ -88,7 +89,7 @@ function Documents({ patient }: { patient: WithId<Patient> }) {
                 element={
                     <PatientDocumentDetails
                         patient={patient}
-                        launchContextParameters={[{ 'name': 'patient', resource: patient }]}/>
+                        launchContextParameters={connectathonDocumentLaunchContext(patient)}/>
                 }
             />
         </Routes>

--- a/src/containers/PatientsUberList/patientDocumentLaunchContext.ts
+++ b/src/containers/PatientsUberList/patientDocumentLaunchContext.ts
@@ -2,7 +2,7 @@ import type { ParametersParameter, Patient } from 'fhir/r4b';
 
 import { getReference, WithId } from '@beda.software/fhir-react';
 
-export function connectathonDocumentLaunchContext(patient: WithId<Patient>): ParametersParameter[] {
+export function patientDocumentLaunchContext(patient: WithId<Patient>): ParametersParameter[] {
     const patientRef = getReference(patient);
 
     return [


### PR DESCRIPTION
## Summary

Combines patient Documents launch context fixes with patient dashboard routing improvements (formerly split across #27 and #26).

- Add `patientDocumentLaunchContext` — passes patient + empty clinical resource stubs when opening connectathon questionnaires from **Patient → Documents**, so SDC `initialExpression` variables like `%Condition.*`, `%Observation.*`, etc. resolve without `undefined-var` errors
- Rework `PatientDetails` routing: splat-based navigation for Documents and dashboard **See all** resource views
- Add `PatientOverviewResources` for full resource lists (Observations, Encounters, Procedures, IPS sections)
- Fix dashboard card keys (`encounters`, `observations`) and use shared `getEffectiveDateTime` for Observation dates (Aidbox-compatible)
- Align `ObservationsUberList` helpers with observation list UI (quantity/date rendering)

## Why merge this first

Patient-scoped connectathon forms opened from **Documents** depend on launch context stubs. Without this PR, Condition / Encounter / Observation / etc. forms fail from Documents even when they work from UberList.

## Merged from #26

PR #26 is closed — its dashboard See all changes are included here to avoid merge conflicts.

## Test plan

- [ ] Open `Patient/patient-single-ex` → **Documents** → create Condition / Encounter / Observation form — no `Context variable … not defined` errors
- [ ] Same forms still work from UberList menus
- [ ] Patient dashboard **See all** on Encounters / Observations opens full resource list
- [ ] Observation dates and values render correctly on dashboard and resource list (including BP components)
- [ ] Documents create / view / edit flow still works (`/documents/new/:questionnaireId`, `/documents/:qrId`)