### PR TITLE
Add PH Core Condition connectathon questionnaire and extract mapper

### DIFF
--- a/resources/seeds/Condition/condition-single-ex.yaml
+++ b/resources/seeds/Condition/condition-single-ex.yaml
@@ -2,22 +2,42 @@ resourceType: Condition
 id: condition-single-ex
 meta:
   profile:
-    - "urn://example.com/ph-core/fhir/StructureDefinition/ph-core-condition"
-    - "http://hl7.org/fhir/uv/ips/StructureDefinition/Condition-uv-ips"
-text:
-  status: generated
-  div: "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><p><b>identifier</b>: id: condition-single-ex</p><p><b>clinicalStatus</b>: <span title=\"Codes: {http://terminology.hl7.org/CodeSystem/condition-clinical active}\">Active</span></p><p><b>code</b>: <span title=\"Codes: {http://snomed.info/sct 44054006}\">Diabetes mellitus type 2</span></p><p><b>subject</b>: <a href=\"#Patient_patient-single-ex\">See above (Patient/patient-single-ex)</a></p></div>"
+    - https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-condition
+    - http://hl7.org/fhir/uv/ips/StructureDefinition/Condition-uv-ips
 clinicalStatus:
   coding:
     - code: active
       system: http://terminology.hl7.org/CodeSystem/condition-clinical
       display: Active
+verificationStatus:
+  coding:
+    - code: confirmed
+      system: http://terminology.hl7.org/CodeSystem/condition-ver-status
+      display: Confirmed
+category:
+  - coding:
+      - system: http://terminology.hl7.org/CodeSystem/condition-category
+        code: problem-list-item
+        display: Problem List Item
+    text: Chronic Condition
 code:
   coding:
     - code: "44054006"
-      system: "http://snomed.info/sct"
-      display: "Diabetes mellitus type 2"
+      system: http://snomed.info/sct
+      display: Diabetes mellitus type 2
+  text: Type 2 Diabetes Mellitus
 subject:
   reference: Patient/patient-single-ex
 encounter:
   reference: Encounter/encounter-single-ex
+onsetDateTime: "2020-03-15"
+recordedDate: "2020-03-15T10:30:00+08:00"
+note:
+  - text: >-
+      Patient diagnosed with T2DM during routine health screening. Currently on
+      Metformin 500mg twice daily.
+text:
+  status: generated
+  div: >-
+    <div xmlns="http://www.w3.org/1999/xhtml">Type 2 Diabetes Mellitus — active,
+    confirmed for Juan Dela Cruz.</div>

--- a/resources/seeds/Mapping/condition-create-extract-connectathon.yaml
+++ b/resources/seeds/Mapping/condition-create-extract-connectathon.yaml
@@ -1,0 +1,92 @@
+id: condition-create-extract-connectathon
+type: FHIRPath
+resourceType: Mapping
+body:
+  "{% assign %}":
+    - id: "{{ %QuestionnaireResponse.answers('conditionId') }}"
+    - patientRef: "{{ %QuestionnaireResponse.answers('patient') }}"
+    - encounterRef: "{{ %QuestionnaireResponse.answers('encounter') }}"
+    - clinicalStatus: "{{ %QuestionnaireResponse.answers('clinical-status') }}"
+    - verificationStatus: "{{ %QuestionnaireResponse.answers('verification-status') }}"
+    - categories: "{[ %QuestionnaireResponse.repeat(item).where(linkId='category').answer.valueCoding ]}"
+    - severity: "{{ %QuestionnaireResponse.answers('severity') }}"
+    - code: "{{ %QuestionnaireResponse.answers('code') }}"
+    - bodySites: "{[ %QuestionnaireResponse.repeat(item).where(linkId='body-site').answer.valueCoding ]}"
+    - recorderRef: "{{ %QuestionnaireResponse.answers('recorder') }}"
+    - asserterRef: "{{ %QuestionnaireResponse.answers('asserter') }}"
+    - onsetDateTime: "{{ %QuestionnaireResponse.answers('onset-date-time') }}"
+    - recordedDate: "{{ %QuestionnaireResponse.answers('recorded-date') }}"
+    - abatementDateTime: "{{ %QuestionnaireResponse.answers('abatement-date-time') }}"
+    - note: "{{ %QuestionnaireResponse.answers('note') }}"
+    - codeDisplay: "{{ iif(%code.display.exists(), %code.display, %code.text) }}"
+    - narrativeDiv: "<div xmlns='http://www.w3.org/1999/xhtml'>PH Core Condition{{ iif(%patientRef.display.exists(), ' for ' + %patientRef.display, '') }}{{ iif(%codeDisplay.exists(), ' — ' + %codeDisplay, '') }}{{ iif(%clinicalStatus.display.exists(), ' — ' + %clinicalStatus.display, iif(%clinicalStatus.code.exists(), ' — ' + %clinicalStatus.code, '')) }}.</div>"
+    - addCondition:
+        request:
+          "{% if %id.exists() %}":
+            url: /Condition/{{ %id }}
+            method: PUT
+          "{% else %}":
+            url: /Condition
+            method: POST
+        resource:
+          resourceType: Condition
+          meta:
+            profile:
+              - https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-condition
+          id:
+            "{% if %id.exists() %}": "{{ %id }}"
+          subject: "{{ %patientRef }}"
+          clinicalStatus:
+            coding:
+              - "{{ %clinicalStatus }}"
+            text: "{{ %clinicalStatus.display }}"
+          text:
+            status: generated
+            div: "{{ %narrativeDiv }}"
+          "{% merge %}":
+            - "{% if %verificationStatus.exists() %}":
+                verificationStatus:
+                  coding:
+                    - "{{ %verificationStatus }}"
+                  text: "{{ %verificationStatus.display }}"
+            - "{% if %categories.exists() %}":
+                category:
+                  - "{% for category in %categories %}":
+                      coding:
+                        - "{{ %category }}"
+                      text: "{{ %category.display }}"
+            - "{% if %severity.exists() %}":
+                severity:
+                  coding:
+                    - "{{ %severity }}"
+                  text: "{{ %severity.display }}"
+            - "{% if %code.exists() %}":
+                code:
+                  coding:
+                    - "{{ %code }}"
+                  text: "{{ %codeDisplay }}"
+            - "{% if %bodySites.exists() %}":
+                bodySite:
+                  - "{% for bodySite in %bodySites %}":
+                      coding:
+                        - "{{ %bodySite }}"
+                      text: "{{ %bodySite.display }}"
+            - "{% if %encounterRef.exists() %}":
+                encounter: "{{ %encounterRef }}"
+            - "{% if %recorderRef.exists() %}":
+                recorder: "{{ %recorderRef }}"
+            - "{% if %asserterRef.exists() %}":
+                asserter: "{{ %asserterRef }}"
+            - "{% if %onsetDateTime.exists() %}":
+                onsetDateTime: "{{ %onsetDateTime }}"
+            - "{% if %recordedDate.exists() %}":
+                recordedDate: "{{ %recordedDate }}"
+            - "{% if %abatementDateTime.exists() %}":
+                abatementDateTime: "{{ %abatementDateTime }}"
+            - "{% if %note.exists() %}":
+                note:
+                  - text: "{{ %note }}"
+  resourceType: Bundle
+  type: transaction
+  entry:
+    - "{{ %addCondition }}"

--- a/resources/seeds/Mapping/condition-create-extract-connectathon.yaml
+++ b/resources/seeds/Mapping/condition-create-extract-connectathon.yaml
@@ -17,8 +17,8 @@ body:
     - onsetDateTime: "{{ %QuestionnaireResponse.item.where(linkId='onset-date-time').answer.valueDateTime.first() }}"
     - recordedDate: "{{ %QuestionnaireResponse.item.where(linkId='recorded-date').answer.valueDateTime.first() }}"
     - note: "{{ %QuestionnaireResponse.answers('note') }}"
-    - codeDisplay: "{{ iif(%code.display.exists(), %code.display, %code.text) }}"
-    - narrativeDiv: "<div xmlns='http://www.w3.org/1999/xhtml'>PH Core Condition{{ iif(%patientRef.display.exists(), ' for ' + %patientRef.display, '') }}{{ iif(%codeDisplay.exists(), ' — ' + %codeDisplay, '') }}{{ iif(%clinicalStatus.display.exists(), ' — ' + %clinicalStatus.display, iif(%clinicalStatus.code.exists(), ' — ' + %clinicalStatus.code, '')) }}.</div>"
+    - codeDisplay: "{{ %code.display | %code.text }}"
+    - narrativeDiv: "<div xmlns='http://www.w3.org/1999/xhtml'>PH Core Condition — {{ %codeDisplay }} — {{ %clinicalStatus.display | %clinicalStatus.code }}.</div>"
     - addCondition:
         request:
           "{% if %id.exists() %}":

--- a/resources/seeds/Mapping/condition-create-extract-connectathon.yaml
+++ b/resources/seeds/Mapping/condition-create-extract-connectathon.yaml
@@ -1,6 +1,6 @@
 id: condition-create-extract-connectathon
-type: FHIRPath
 resourceType: Mapping
+type: FHIRPath
 body:
   "{% assign %}":
     - id: "{{ %QuestionnaireResponse.answers('conditionId') }}"
@@ -8,10 +8,10 @@ body:
     - encounterRef: "{{ %QuestionnaireResponse.answers('encounter') }}"
     - clinicalStatus: "{{ %QuestionnaireResponse.answers('clinical-status') }}"
     - verificationStatus: "{{ %QuestionnaireResponse.answers('verification-status') }}"
-    - categories: "{[ %QuestionnaireResponse.repeat(item).where(linkId='category').answer.valueCoding ]}"
+    - categories: "{[ %QuestionnaireResponse.item.where(linkId='category').answer.valueCoding ]}"
     - severity: "{{ %QuestionnaireResponse.answers('severity') }}"
     - code: "{{ %QuestionnaireResponse.answers('code') }}"
-    - bodySites: "{[ %QuestionnaireResponse.repeat(item).where(linkId='body-site').answer.valueCoding ]}"
+    - bodySites: "{[ %QuestionnaireResponse.item.where(linkId='body-site').answer.valueCoding ]}"
     - recorderRef: "{{ %QuestionnaireResponse.answers('recorder') }}"
     - asserterRef: "{{ %QuestionnaireResponse.answers('asserter') }}"
     - onsetDateTime: "{{ %QuestionnaireResponse.item.where(linkId='onset-date-time').answer.valueDateTime.first() }}"
@@ -32,8 +32,7 @@ body:
           meta:
             profile:
               - https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-condition
-          id:
-            "{% if %id.exists() %}": "{{ %id }}"
+          id: "{{ %id }}"
           subject: "{{ %patientRef }}"
           clinicalStatus:
             coding:
@@ -42,47 +41,38 @@ body:
           text:
             status: generated
             div: "{{ %narrativeDiv }}"
-          "{% merge %}":
-            - "{% if %verificationStatus.exists() %}":
-                verificationStatus:
-                  coding:
-                    - "{{ %verificationStatus }}"
-                  text: "{{ %verificationStatus.display }}"
-            - "{% if %categories.exists() %}":
-                category:
-                  - "{% for category in %categories %}":
-                      coding:
-                        - "{{ %category }}"
-                      text: "{{ %category.display }}"
-            - "{% if %severity.exists() %}":
-                severity:
-                  coding:
-                    - "{{ %severity }}"
-                  text: "{{ %severity.display }}"
-            - "{% if %code.exists() %}":
-                code:
-                  coding:
-                    - "{{ %code }}"
-                  text: "{{ %codeDisplay }}"
-            - "{% if %bodySites.exists() %}":
-                bodySite:
-                  - "{% for bodySite in %bodySites %}":
-                      coding:
-                        - "{{ %bodySite }}"
-                      text: "{{ %bodySite.display }}"
-            - "{% if %encounterRef.exists() %}":
-                encounter: "{{ %encounterRef }}"
-            - "{% if %recorderRef.exists() %}":
-                recorder: "{{ %recorderRef }}"
-            - "{% if %asserterRef.exists() %}":
-                asserter: "{{ %asserterRef }}"
-            - "{% if %onsetDateTime.exists() %}":
-                onsetDateTime: "{{ %onsetDateTime }}"
-            - "{% if %recordedDate.exists() %}":
-                recordedDate: "{{ %recordedDate }}"
+          verificationStatus:
+            "{% if %verificationStatus.exists() %}":
+              coding:
+                - "{{ %verificationStatus }}"
+              text: "{{ %verificationStatus.display }}"
+          category:
+            - "{% for category in %categories %}":
+                coding:
+                  - "{{ %category }}"
+                text: "{{ %category.display }}"
+          severity:
+            "{% if %severity.exists() %}":
+              coding:
+                - "{{ %severity }}"
+              text: "{{ %severity.display }}"
+          code:
+            coding:
+              - "{{ %code }}"
+            text: "{{ %codeDisplay }}"
+          bodySite:
+            - "{% for bodySite in %bodySites %}":
+                coding:
+                  - "{{ %bodySite }}"
+                text: "{{ %bodySite.display }}"
+          encounter: "{{ %encounterRef }}"
+          recorder: "{{ %recorderRef }}"
+          asserter: "{{ %asserterRef }}"
+          onsetDateTime: "{{ %onsetDateTime }}"
+          recordedDate: "{{ %recordedDate }}"
+          note:
             - "{% if %note.exists() %}":
-                note:
-                  - text: "{{ %note }}"
+                text: "{{ %note }}"
   resourceType: Bundle
   type: transaction
   entry:

--- a/resources/seeds/Mapping/condition-create-extract-connectathon.yaml
+++ b/resources/seeds/Mapping/condition-create-extract-connectathon.yaml
@@ -14,9 +14,8 @@ body:
     - bodySites: "{[ %QuestionnaireResponse.repeat(item).where(linkId='body-site').answer.valueCoding ]}"
     - recorderRef: "{{ %QuestionnaireResponse.answers('recorder') }}"
     - asserterRef: "{{ %QuestionnaireResponse.answers('asserter') }}"
-    - onsetDateTime: "{{ %QuestionnaireResponse.answers('onset-date-time') }}"
-    - recordedDate: "{{ %QuestionnaireResponse.answers('recorded-date') }}"
-    - abatementDateTime: "{{ %QuestionnaireResponse.answers('abatement-date-time') }}"
+    - onsetDateTime: "{{ %QuestionnaireResponse.item.where(linkId='onset-date-time').answer.valueDateTime.first() }}"
+    - recordedDate: "{{ %QuestionnaireResponse.item.where(linkId='recorded-date').answer.valueDateTime.first() }}"
     - note: "{{ %QuestionnaireResponse.answers('note') }}"
     - codeDisplay: "{{ iif(%code.display.exists(), %code.display, %code.text) }}"
     - narrativeDiv: "<div xmlns='http://www.w3.org/1999/xhtml'>PH Core Condition{{ iif(%patientRef.display.exists(), ' for ' + %patientRef.display, '') }}{{ iif(%codeDisplay.exists(), ' — ' + %codeDisplay, '') }}{{ iif(%clinicalStatus.display.exists(), ' — ' + %clinicalStatus.display, iif(%clinicalStatus.code.exists(), ' — ' + %clinicalStatus.code, '')) }}.</div>"
@@ -81,8 +80,6 @@ body:
                 onsetDateTime: "{{ %onsetDateTime }}"
             - "{% if %recordedDate.exists() %}":
                 recordedDate: "{{ %recordedDate }}"
-            - "{% if %abatementDateTime.exists() %}":
-                abatementDateTime: "{{ %abatementDateTime }}"
             - "{% if %note.exists() %}":
                 note:
                   - text: "{{ %note }}"

--- a/resources/seeds/Questionnaire/condition-create-connectathon.yaml
+++ b/resources/seeds/Questionnaire/condition-create-connectathon.yaml
@@ -1,115 +1,102 @@
+resourceType: Questionnaire
+id: condition-create-connectathon
+name: condition-create-connectathon
+title: Condition create PH
+status: active
+url: condition-create
+subjectType:
+  - Patient
 meta:
   profile:
     - https://emr-core.beda.software/StructureDefinition/fhir-emr-questionnaire
-name: condition-create-connectathon
+mapping:
+  - reference: Mapping/condition-create-extract-connectathon
+launchContext:
+  - name:
+      code: Condition
+    type:
+      - Condition
+  - name:
+      code: Patient
+    type:
+      - Patient
 item:
-  - text: ConditionId
+  - linkId: conditionId
+    text: ConditionId
     type: string
-    linkId: conditionId
-    extension:
-      - url: http://hl7.org/fhir/StructureDefinition/questionnaire-hidden
-        valueBoolean: true
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
-        valueExpression:
-          language: text/fhirpath
-          expression: '%Condition.id'
-  - text: Patient
+    hidden: true
+    initialExpression:
+      language: text/fhirpath
+      expression: "%Condition.id"
+
+  - linkId: patient
+    text: Patient
     type: reference
-    linkId: patient
     required: true
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-choiceColumn
-        extension:
-          - url: path
-            valueString: >-
-              name.given.first() + ' ' + name.family.first()
-          - url: forDisplay
-            valueBoolean: true
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-answerExpression
-        valueExpression:
-          language: application/x-fhir-query
-          expression: Patient
-      - url: >-
-          http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource
-        valueCode: Patient
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
-        valueExpression:
-          language: text/fhirpath
-          expression: "iif(%Condition.subject.exists(), %Condition.subject, %Patient)"
-  - text: Encounter
+    referenceResource:
+      - Patient
+    answerExpression:
+      language: application/x-fhir-query
+      expression: Patient
+    choiceColumn:
+      - forDisplay: true
+        path: name.given.first() + ' ' + name.family.first()
+    initialExpression:
+      language: text/fhirpath
+      expression: "iif(%Condition.subject.exists(), %Condition.subject, %Patient)"
+
+  - linkId: encounter
+    text: Encounter
     type: reference
-    linkId: encounter
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-choiceColumn
-        extension:
-          - url: path
-            valueString: >-
-              class.display + ' - ' + period.start.toString().split('.')[0].split('T')[0] + ' ' + period.start.toString().split('.')[0].split('T')[1]
-          - url: forDisplay
-            valueBoolean: true
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-answerExpression
-        valueExpression:
-          language: application/x-fhir-query
-          expression: Encounter?patient={{%QuestionnaireResponse.repeat(item).where(linkId='patient').answer.valueReference.reference}}
-      - url: >-
-          http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource
-        valueCode: Encounter
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
-        valueExpression:
-          language: text/fhirpath
-          expression: '%Condition.encounter'
-  - text: Clinical status
+    referenceResource:
+      - Encounter
+    answerExpression:
+      language: application/x-fhir-query
+      expression: "Encounter?patient={{%QuestionnaireResponse.repeat(item).where(linkId='patient').answer.valueReference.reference}}"
+    choiceColumn:
+      - forDisplay: true
+        path: class.display + ' - ' + period.start.toString().split('.')[0].split('T')[0] + ' ' + period.start.toString().split('.')[0].split('T')[1]
+    initialExpression:
+      language: text/fhirpath
+      expression: "%Condition.encounter"
+
+  - linkId: clinical-status
+    text: Clinical status
     type: choice
-    linkId: clinical-status
     required: true
     answerValueSet: http://hl7.org/fhir/ValueSet/condition-clinical
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
-        valueExpression:
-          language: text/fhirpath
-          expression: '%Condition.clinicalStatus.coding.first()'
-  - text: Verification status
+    initialExpression:
+      language: text/fhirpath
+      expression: "%Condition.clinicalStatus.coding.first()"
+
+  - linkId: verification-status
+    text: Verification status
     type: choice
-    linkId: verification-status
     answerValueSet: http://hl7.org/fhir/ValueSet/condition-ver-status
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
-        valueExpression:
-          language: text/fhirpath
-          expression: '%Condition.verificationStatus.coding.first()'
-  - text: Category
+    initialExpression:
+      language: text/fhirpath
+      expression: "%Condition.verificationStatus.coding.first()"
+
+  - linkId: category
+    text: Category
     type: choice
-    linkId: category
     repeats: true
     answerValueSet: http://hl7.org/fhir/ValueSet/condition-category
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
-        valueExpression:
-          language: text/fhirpath
-          expression: '%Condition.category.coding'
-  - text: Severity
+    initialExpression:
+      language: text/fhirpath
+      expression: "%Condition.category.coding"
+
+  - linkId: severity
+    text: Severity
     type: choice
-    linkId: severity
     answerValueSet: http://hl7.org/fhir/ValueSet/condition-severity
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
-        valueExpression:
-          language: text/fhirpath
-          expression: '%Condition.severity.coding.first()'
-  - text: Condition code
+    initialExpression:
+      language: text/fhirpath
+      expression: "%Condition.severity.coding.first()"
+
+  - linkId: code
+    text: Condition code
     type: choice
-    linkId: code
     required: true
     # TODO: uncomment answerValueSet when tx.fhirlab.net expands condition-code reliably
     # answerValueSet: http://hl7.org/fhir/ValueSet/condition-code
@@ -118,115 +105,66 @@ item:
           system: http://snomed.info/sct
           code: "44054006"
           display: Diabetes mellitus type 2
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
-        valueExpression:
-          language: text/fhirpath
-          expression: '%Condition.code.coding.first()'
-  - text: Body site
+    initialExpression:
+      language: text/fhirpath
+      expression: "%Condition.code.coding.first()"
+
+  - linkId: body-site
+    text: Body site
     type: choice
-    linkId: body-site
     repeats: true
     answerValueSet: http://hl7.org/fhir/ValueSet/body-site
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
-        valueExpression:
-          language: text/fhirpath
-          expression: '%Condition.bodySite.coding'
-  - text: Recorder
+    initialExpression:
+      language: text/fhirpath
+      expression: "%Condition.bodySite.coding"
+
+  - linkId: recorder
+    text: Recorder
     type: reference
-    linkId: recorder
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-choiceColumn
-        extension:
-          - url: path
-            valueString: >-
-              name.given.first() + ' ' + name.family
-          - url: forDisplay
-            valueBoolean: true
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-answerExpression
-        valueExpression:
-          language: application/x-fhir-query
-          expression: Practitioner
-      - url: >-
-          http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource
-        valueCode: Practitioner
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
-        valueExpression:
-          language: text/fhirpath
-          expression: '%Condition.recorder'
-  - text: Asserter
+    referenceResource:
+      - Practitioner
+    answerExpression:
+      language: application/x-fhir-query
+      expression: Practitioner
+    choiceColumn:
+      - forDisplay: true
+        path: name.given.first() + ' ' + name.family
+    initialExpression:
+      language: text/fhirpath
+      expression: "%Condition.recorder"
+
+  - linkId: asserter
+    text: Asserter
     type: reference
-    linkId: asserter
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-choiceColumn
-        extension:
-          - url: path
-            valueString: >-
-              name.given.first() + ' ' + name.family
-          - url: forDisplay
-            valueBoolean: true
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-answerExpression
-        valueExpression:
-          language: application/x-fhir-query
-          expression: Practitioner
-      - url: >-
-          http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource
-        valueCode: Practitioner
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
-        valueExpression:
-          language: text/fhirpath
-          expression: '%Condition.asserter'
-  - text: Onset date and time
+    referenceResource:
+      - Practitioner
+    answerExpression:
+      language: application/x-fhir-query
+      expression: Practitioner
+    choiceColumn:
+      - forDisplay: true
+        path: name.given.first() + ' ' + name.family
+    initialExpression:
+      language: text/fhirpath
+      expression: "%Condition.asserter"
+
+  - linkId: onset-date-time
+    text: Onset date and time
     type: dateTime
-    linkId: onset-date-time
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
-        valueExpression:
-          language: text/fhirpath
-          expression: '%Condition.onsetDateTime'
-  - text: Recorded date
+    initialExpression:
+      language: text/fhirpath
+      expression: "%Condition.onsetDateTime"
+
+  - linkId: recorded-date
+    text: Recorded date
     type: dateTime
-    linkId: recorded-date
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
-        valueExpression:
-          language: text/fhirpath
-          expression: '%Condition.recordedDate'
-  - text: Note
+    initialExpression:
+      language: text/fhirpath
+      expression: "%Condition.recordedDate"
+
+  - linkId: note
+    text: Note
     type: text
-    linkId: note
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
-        valueExpression:
-          language: text/fhirpath
-          expression: '%Condition.note.text.first()'
-resourceType: Questionnaire
-title: Condition create PH
-subjectType:
-  - Patient
-extension:
-  - url: https://emr-core.beda.software/StructureDefinition/questionnaire-mapper
-    valueReference:
-      reference: Mapping/condition-create-extract-connectathon
-  - url: http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext
-    extension:
-      - url: name
-        valueCoding:
-          code: Condition
-      - url: type
-        valueCode: Condition
-status: active
-id: condition-create-connectathon
-url: condition-create
+    initialExpression:
+      language: text/fhirpath
+      expression: "%Condition.note.text.first()"

--- a/resources/seeds/Questionnaire/condition-create-connectathon.yaml
+++ b/resources/seeds/Questionnaire/condition-create-connectathon.yaml
@@ -39,7 +39,7 @@ item:
           http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
         valueExpression:
           language: text/fhirpath
-          expression: '%Condition.subject'
+          expression: "iif(%Condition.subject.exists(), %Condition.subject, %Patient)"
   - text: Encounter
     type: reference
     linkId: encounter
@@ -203,15 +203,6 @@ item:
         valueExpression:
           language: text/fhirpath
           expression: '%Condition.recordedDate'
-  - text: Abatement date and time
-    type: dateTime
-    linkId: abatement-date-time
-    extension:
-      - url: >-
-          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
-        valueExpression:
-          language: text/fhirpath
-          expression: '%Condition.abatementDateTime'
   - text: Note
     type: text
     linkId: note

--- a/resources/seeds/Questionnaire/condition-create-connectathon.yaml
+++ b/resources/seeds/Questionnaire/condition-create-connectathon.yaml
@@ -223,6 +223,8 @@ item:
           expression: '%Condition.note.text.first()'
 resourceType: Questionnaire
 title: Condition create PH
+subjectType:
+  - Patient
 extension:
   - url: https://emr-core.beda.software/StructureDefinition/questionnaire-mapper
     valueReference:

--- a/resources/seeds/Questionnaire/condition-create-connectathon.yaml
+++ b/resources/seeds/Questionnaire/condition-create-connectathon.yaml
@@ -1,0 +1,239 @@
+meta:
+  profile:
+    - https://emr-core.beda.software/StructureDefinition/fhir-emr-questionnaire
+name: condition-create-connectathon
+item:
+  - text: ConditionId
+    type: string
+    linkId: conditionId
+    extension:
+      - url: http://hl7.org/fhir/StructureDefinition/questionnaire-hidden
+        valueBoolean: true
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
+        valueExpression:
+          language: text/fhirpath
+          expression: '%Condition.id'
+  - text: Patient
+    type: reference
+    linkId: patient
+    required: true
+    extension:
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-choiceColumn
+        extension:
+          - url: path
+            valueString: >-
+              name.given.first() + ' ' + name.family.first()
+          - url: forDisplay
+            valueBoolean: true
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-answerExpression
+        valueExpression:
+          language: application/x-fhir-query
+          expression: Patient
+      - url: >-
+          http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource
+        valueCode: Patient
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
+        valueExpression:
+          language: text/fhirpath
+          expression: '%Condition.subject'
+  - text: Encounter
+    type: reference
+    linkId: encounter
+    extension:
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-choiceColumn
+        extension:
+          - url: path
+            valueString: >-
+              class.display + ' - ' + period.start.toString().split('.')[0].split('T')[0] + ' ' + period.start.toString().split('.')[0].split('T')[1]
+          - url: forDisplay
+            valueBoolean: true
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-answerExpression
+        valueExpression:
+          language: application/x-fhir-query
+          expression: Encounter?patient={{%QuestionnaireResponse.repeat(item).where(linkId='patient').answer.valueReference.reference}}
+      - url: >-
+          http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource
+        valueCode: Encounter
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
+        valueExpression:
+          language: text/fhirpath
+          expression: '%Condition.encounter'
+  - text: Clinical status
+    type: choice
+    linkId: clinical-status
+    required: true
+    answerValueSet: http://hl7.org/fhir/ValueSet/condition-clinical
+    extension:
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
+        valueExpression:
+          language: text/fhirpath
+          expression: '%Condition.clinicalStatus.coding.first()'
+  - text: Verification status
+    type: choice
+    linkId: verification-status
+    answerValueSet: http://hl7.org/fhir/ValueSet/condition-ver-status
+    extension:
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
+        valueExpression:
+          language: text/fhirpath
+          expression: '%Condition.verificationStatus.coding.first()'
+  - text: Category
+    type: choice
+    linkId: category
+    repeats: true
+    answerValueSet: http://hl7.org/fhir/ValueSet/condition-category
+    extension:
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
+        valueExpression:
+          language: text/fhirpath
+          expression: '%Condition.category.coding'
+  - text: Severity
+    type: choice
+    linkId: severity
+    answerValueSet: http://hl7.org/fhir/ValueSet/condition-severity
+    extension:
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
+        valueExpression:
+          language: text/fhirpath
+          expression: '%Condition.severity.coding.first()'
+  - text: Condition code
+    type: choice
+    linkId: code
+    required: true
+    # TODO: uncomment answerValueSet when tx.fhirlab.net expands condition-code reliably
+    # answerValueSet: http://hl7.org/fhir/ValueSet/condition-code
+    answerOption:
+      - valueCoding:
+          system: http://snomed.info/sct
+          code: "44054006"
+          display: Diabetes mellitus type 2
+    extension:
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
+        valueExpression:
+          language: text/fhirpath
+          expression: '%Condition.code.coding.first()'
+  - text: Body site
+    type: choice
+    linkId: body-site
+    repeats: true
+    answerValueSet: http://hl7.org/fhir/ValueSet/body-site
+    extension:
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
+        valueExpression:
+          language: text/fhirpath
+          expression: '%Condition.bodySite.coding'
+  - text: Recorder
+    type: reference
+    linkId: recorder
+    extension:
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-choiceColumn
+        extension:
+          - url: path
+            valueString: >-
+              name.given.first() + ' ' + name.family
+          - url: forDisplay
+            valueBoolean: true
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-answerExpression
+        valueExpression:
+          language: application/x-fhir-query
+          expression: Practitioner
+      - url: >-
+          http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource
+        valueCode: Practitioner
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
+        valueExpression:
+          language: text/fhirpath
+          expression: '%Condition.recorder'
+  - text: Asserter
+    type: reference
+    linkId: asserter
+    extension:
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-choiceColumn
+        extension:
+          - url: path
+            valueString: >-
+              name.given.first() + ' ' + name.family
+          - url: forDisplay
+            valueBoolean: true
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-answerExpression
+        valueExpression:
+          language: application/x-fhir-query
+          expression: Practitioner
+      - url: >-
+          http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource
+        valueCode: Practitioner
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
+        valueExpression:
+          language: text/fhirpath
+          expression: '%Condition.asserter'
+  - text: Onset date and time
+    type: dateTime
+    linkId: onset-date-time
+    extension:
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
+        valueExpression:
+          language: text/fhirpath
+          expression: '%Condition.onsetDateTime'
+  - text: Recorded date
+    type: dateTime
+    linkId: recorded-date
+    extension:
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
+        valueExpression:
+          language: text/fhirpath
+          expression: '%Condition.recordedDate'
+  - text: Abatement date and time
+    type: dateTime
+    linkId: abatement-date-time
+    extension:
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
+        valueExpression:
+          language: text/fhirpath
+          expression: '%Condition.abatementDateTime'
+  - text: Note
+    type: text
+    linkId: note
+    extension:
+      - url: >-
+          http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression
+        valueExpression:
+          language: text/fhirpath
+          expression: '%Condition.note.text.first()'
+resourceType: Questionnaire
+title: Condition create PH
+extension:
+  - url: https://emr-core.beda.software/StructureDefinition/questionnaire-mapper
+    valueReference:
+      reference: Mapping/condition-create-extract-connectathon
+  - url: http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext
+    extension:
+      - url: name
+        valueCoding:
+          code: Condition
+      - url: type
+        valueCode: Condition
+status: active
+id: condition-create-connectathon
+url: condition-create

--- a/src/containers/ConditionsUberList/index.tsx
+++ b/src/containers/ConditionsUberList/index.tsx
@@ -1,0 +1,122 @@
+import { PlusOutlined } from '@ant-design/icons';
+import { t, Trans } from '@lingui/macro';
+import { Bundle, Condition, Patient } from 'fhir/r4b';
+
+import { questionnaireAction, ResourceListPage } from '@beda.software/emr/components';
+import { SearchBarColumnType } from '@beda.software/emr/dist/components/SearchBar/types';
+import { compileAsFirst } from '@beda.software/emr/utils';
+
+const getConditionCode = compileAsFirst<Condition, string>(
+    'Condition.code.text | Condition.code.coding.first().display',
+);
+const getClinicalStatus = compileAsFirst<Condition, string>(
+    'Condition.clinicalStatus.text | Condition.clinicalStatus.coding.first().display',
+);
+
+function patientFromBundle(bundle: Bundle, patientRef?: string) {
+    const patientId = patientRef?.replace('Patient/', '');
+    if (!patientId) {
+        return undefined;
+    }
+
+    return bundle.entry
+        ?.map((entry) => entry.resource)
+        .find(
+            (resource): resource is Patient =>
+                resource?.resourceType === 'Patient' && resource.id === patientId,
+        );
+}
+
+function conditionLaunchContext(resource: Condition, bundle?: Bundle) {
+    const patientId = resource.subject?.reference?.replace('Patient/', '');
+    const patient =
+        patientFromBundle(bundle ?? { resourceType: 'Bundle', type: 'searchset' }, resource.subject?.reference) ??
+        (patientId
+            ? ({ resourceType: 'Patient', id: patientId } as Patient)
+            : ({ resourceType: 'Patient' } as Patient));
+
+    return [
+        { name: 'Condition', resource },
+        { name: 'Patient', resource: patient },
+    ];
+}
+
+export function ConditionsUberList() {
+    return (
+        <ResourceListPage<Condition>
+            headerTitle={t`Conditions`}
+            resourceType="Condition"
+            searchParams={{ _include: ['Condition:subject'] }}
+            getTableColumns={() => [
+                {
+                    title: <Trans>Patient</Trans>,
+                    dataIndex: 'subject',
+                    key: 'subject',
+                    render: (_text, { resource }) =>
+                        resource.subject?.display ?? resource.subject?.reference,
+                    width: 250,
+                },
+                {
+                    title: <Trans>Code</Trans>,
+                    dataIndex: 'code',
+                    key: 'code',
+                    render: (_text, { resource }) => getConditionCode(resource),
+                    width: 280,
+                },
+                {
+                    title: <Trans>Clinical status</Trans>,
+                    dataIndex: 'clinicalStatus',
+                    key: 'clinicalStatus',
+                    render: (_text, { resource }) => getClinicalStatus(resource),
+                    width: 150,
+                },
+            ]}
+            getFilters={() => [
+                {
+                    id: 'patient',
+                    searchParam: 'patient:Patient.name',
+                    type: SearchBarColumnType.STRING,
+                    placeholder: t`Find by patient`,
+                    placement: ['search-bar', 'table'],
+                },
+                {
+                    id: 'code',
+                    searchParam: 'code',
+                    type: SearchBarColumnType.STRING,
+                    placeholder: t`Find by code`,
+                    placement: ['search-bar', 'table'],
+                },
+            ]}
+            getRecordActions={(record) => [
+                questionnaireAction('Edit', 'condition-create-connectathon', {
+                    extra: {
+                        qrfProps: {
+                            launchContextParameters: conditionLaunchContext(
+                                record.resource,
+                                record.bundle,
+                            ),
+                        },
+                    },
+                }),
+            ]}
+            getHeaderActions={() => [
+                questionnaireAction(<Trans>Add condition</Trans>, 'condition-create-connectathon', {
+                    icon: <PlusOutlined />,
+                    extra: {
+                        qrfProps: {
+                            launchContextParameters: conditionLaunchContext({
+                                resourceType: 'Condition',
+                            }),
+                        },
+                    },
+                }),
+            ]}
+            getReportColumns={(bundle) => [
+                {
+                    title: t`Number of conditions`,
+                    value: bundle.total,
+                },
+            ]}
+        />
+    );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -39,6 +39,7 @@ import { matchCurrentUserRole, Role } from '@beda.software/emr/utils';
 import { isSuccess, RemoteDataResult, isFailure } from '@beda.software/remote-data';
 
 import { Analytics } from './containers/Analytics';
+import { ConditionsUberList } from './containers/ConditionsUberList';
 import { EncountersUberList } from './containers/EncountersUberList';
 import { ImmunizationsUberList } from './containers/ImmunizationsUberList ';
 import { MedicationsUberList } from './containers/MedicationsUberList';
@@ -143,6 +144,7 @@ function menuLayout() {
             { label: t`Observations`, path: '/observations-ph', icon: <ServicesIcon /> },
             { label: t`Medications`, path: '/medications-ph', icon: <MedicationsIcon /> },
             { label: t`Procedures`, path: '/procedures-ph', icon: <ServicesIcon /> },
+            { label: t`Conditions`, path: '/conditions-ph', icon: <ServicesIcon /> },
             { label: t`Questionnaire`, path: '/questionnaires-ph', icon: <ServicesIcon /> },
             { label: t`Analytics`, path: '/analytics-ph', icon: <ServicesIcon /> },
         ],
@@ -178,6 +180,7 @@ export const AppWithContext = () => {
                                     <Route path="/practitioners-ph" element={<PractitionersUberList />} />
                                     <Route path="/organizations-ph" element={<OrganizationsUberList />} />
                                     <Route path="/procedures-ph" element={<ProceduresUberList />} />
+                                    <Route path="/conditions-ph" element={<ConditionsUberList />} />
                                     <Route path="/immunizations-ph" element={<ImmunizationsUberList />} />
                                     <Route path="/observations-ph" element={<ObservationsUberList />} />
                                     <Route path="/medications-ph" element={<MedicationsUberList />} />


### PR DESCRIPTION
## Summary
- Migrate `condition-create-connectathon` to FCE with dual Patient/Condition launch context.
- Flatten extract mapper; respect PH Core cardinality (category/bodySite/note arrays vs verificationStatus object).
- Keep condition-code SNOMED stub until terminology expands.

**Depends on:** launch context PR #27 (Documents need Condition stub in launch context)

## Test plan
- [x] `$populate` + `$extract` round-trip with `condition-single-ex`
- [x] `$extract` with verification-status on create
- [ ] UI: Create/edit condition from patient Documents PR #27