### PR TITLE
Fix dev white screen when opening EMR questionnaire modals

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,7 +32,20 @@ export default defineConfig(({ command }) => ({
     resolve: {
         alias: [
             { find: 'src', replacement: path.resolve(__dirname, './src/') },
+            {
+                find: 'styled-components',
+                replacement: path.resolve(__dirname, 'node_modules/styled-components'),
+            },
+            {
+                find: '@lingui/react',
+                replacement: path.resolve(__dirname, 'node_modules/@lingui/react'),
+            },
+            {
+                find: '@lingui/core',
+                replacement: path.resolve(__dirname, 'node_modules/@lingui/core'),
+            },
         ],
+        dedupe: ['styled-components', 'react', 'react-dom', '@lingui/react', '@lingui/core'],
     },
     define: {
         'process.env': {},


### PR DESCRIPTION
## Summary

Fix local dev crashes (white screen) when opening questionnaire modals from connectathon UberLists (e.g. **Add patient** on `/patients-ph`).

The app hosts `ThemeProvider` / `I18nProvider` from root `node_modules`, while `@beda.software/emr` resolves `styled-components` and `@lingui/*` from `contrib/fhir-emr/node_modules`. React context does not cross duplicate package instances, which leads to:

- `Cannot read properties of undefined (reading 'bcp_1')` (styled-components theme)
- `Trans was rendered without I18nProvider` (Lingui)

Add Vite `resolve.alias` and `resolve.dedupe` so the host app and EMR submodule share one copy of `styled-components`, `@lingui/react`, and `@lingui/core`.

**Scope:** dev/build bundling only — no questionnaire, mapper, or seed changes.

## Test plan

- [x] `yarn vite` (or `yarn vite --force` after branch switch)
- [x] Open `/patients-ph` → **Add patient** → form renders (no white screen)
- [ ] Open another connectathon list (e.g. `/organizations-ph` → Add organization) → modal opens
- [ ] Console: no `bcp_1` / `I18nProvider` errors on page load or modal open