### PR TITLE
Complete PH Core profile filtering for lists and forms

### DIFF
--- a/resources/seeds/Questionnaire/curated-ips.yaml
+++ b/resources/seeds/Questionnaire/curated-ips.yaml
@@ -318,7 +318,7 @@ item:
                   expression: "%context.medicationReference"
                 answerExpression:
                   language: application/x-fhir-query
-                  expression: "Medication?status=active"
+                  expression: "Medication?status=active&_profile=https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-medication"
                 referenceResource:
                   - Medication
                 choiceColumn:

--- a/resources/seeds/Questionnaire/encounter-create-connectathon.yaml
+++ b/resources/seeds/Questionnaire/encounter-create-connectathon.yaml
@@ -40,7 +40,7 @@ item:
       - Patient
     answerExpression:
       language: application/x-fhir-query
-      expression: Patient
+      expression: Patient?_profile=https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-patient
     choiceColumn:
       - forDisplay: true
         path: name.given.first() + ' ' + name.family.first()
@@ -55,7 +55,7 @@ item:
       - Practitioner
     answerExpression:
       language: application/x-fhir-query
-      expression: Practitioner
+      expression: Practitioner?_profile=https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-practitioner
     choiceColumn:
       - forDisplay: true
         path: name.given.first() + ' ' + name.family
@@ -114,7 +114,7 @@ item:
       - Organization
     answerExpression:
       language: application/x-fhir-query
-      expression: Organization
+      expression: Organization?_profile=https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-organization
     choiceColumn:
       - forDisplay: true
         path: name

--- a/resources/seeds/Questionnaire/immunization-create-connectathon.yaml
+++ b/resources/seeds/Questionnaire/immunization-create-connectathon.yaml
@@ -33,7 +33,7 @@ item:
       - Patient
     answerExpression:
       language: application/x-fhir-query
-      expression: Patient
+      expression: Patient?_profile=https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-patient
     choiceColumn:
       - forDisplay: true
         path: name.given.first() + ' ' + name.family.first()
@@ -94,7 +94,7 @@ item:
       - Encounter
     answerExpression:
       language: application/x-fhir-query
-      expression: "Encounter?patient={{%QuestionnaireResponse.repeat(item).where(linkId='patient').answer.valueReference.reference}}"
+      expression: "Encounter?patient={{%QuestionnaireResponse.repeat(item).where(linkId='patient').answer.valueReference.reference}}&_profile=https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-encounter"
     choiceColumn:
       - forDisplay: true
         path: class.display + ' - ' + period.start.toString().split('.')[0].split('T')[0] + ' ' + period.start.toString().split('.')[0].split('T')[1]
@@ -109,7 +109,7 @@ item:
       - Practitioner
     answerExpression:
       language: application/x-fhir-query
-      expression: Practitioner
+      expression: Practitioner?_profile=https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-practitioner
     choiceColumn:
       - forDisplay: true
         path: name.given.first() + ' ' + name.family
@@ -189,7 +189,7 @@ item:
       - Medication
     answerExpression:
       language: application/x-fhir-query
-      expression: Medication
+      expression: Medication?_profile=https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-medication
     choiceColumn:
       - forDisplay: true
         path: code.coding.first().display

--- a/resources/seeds/Questionnaire/observation-create-connectathon.yaml
+++ b/resources/seeds/Questionnaire/observation-create-connectathon.yaml
@@ -25,7 +25,7 @@ item:
       - Patient
     answerExpression:
       language: application/x-fhir-query
-      expression: Patient
+      expression: Patient?_profile=https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-patient
     choiceColumn:
       - forDisplay: true
         path: name.given.first() + ' ' + name.family.first()
@@ -40,7 +40,7 @@ item:
       - Encounter
     answerExpression:
       language: application/x-fhir-query
-      expression: "Encounter?patient={{%QuestionnaireResponse.repeat(item).where(linkId='patient').answer.valueReference.reference}}"
+      expression: "Encounter?patient={{%QuestionnaireResponse.repeat(item).where(linkId='patient').answer.valueReference.reference}}&_profile=https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-encounter"
     choiceColumn:
       - forDisplay: true
         path: class.display + ' - ' + period.start.toString()
@@ -52,7 +52,7 @@ item:
       - Practitioner
     answerExpression:
       language: application/x-fhir-query
-      expression: Practitioner
+      expression: Practitioner?_profile=https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-practitioner
     choiceColumn:
       - forDisplay: true
         path: name.given.first() + ' ' + name.family

--- a/resources/seeds/Questionnaire/practitionerrole-create-connectathon.yaml
+++ b/resources/seeds/Questionnaire/practitionerrole-create-connectathon.yaml
@@ -35,7 +35,7 @@ item:
       - Practitioner
     answerExpression:
       language: application/x-fhir-query
-      expression: Practitioner
+      expression: Practitioner?_profile=https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-practitioner
     choiceColumn:
       - forDisplay: true
         path: name.given.first() + ' ' + name.family.first()
@@ -50,7 +50,7 @@ item:
       - Organization
     answerExpression:
       language: application/x-fhir-query
-      expression: Organization
+      expression: Organization?_profile=https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-organization
     choiceColumn:
       - forDisplay: true
         path: name

--- a/resources/seeds/Questionnaire/procedure-create-connectathon.yaml
+++ b/resources/seeds/Questionnaire/procedure-create-connectathon.yaml
@@ -33,7 +33,7 @@ item:
       - Patient
     answerExpression:
       language: application/x-fhir-query
-      expression: Patient
+      expression: Patient?_profile=https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-patient
     choiceColumn:
       - forDisplay: true
         path: name.given.first() + ' ' + name.family.first()
@@ -48,7 +48,7 @@ item:
       - Encounter
     answerExpression:
       language: application/x-fhir-query
-      expression: "Encounter?patient={{%QuestionnaireResponse.repeat(item).where(linkId='patient').answer.valueReference.reference}}"
+      expression: "Encounter?patient={{%QuestionnaireResponse.repeat(item).where(linkId='patient').answer.valueReference.reference}}&_profile=https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-encounter"
     choiceColumn:
       - forDisplay: true
         path: class.display + ' - ' + period.start.toString().split('.')[0].split('T')[0] + ' ' + period.start.toString().split('.')[0].split('T')[1]

--- a/src/containers/EncountersUberList/index.tsx
+++ b/src/containers/EncountersUberList/index.tsx
@@ -17,6 +17,7 @@ export function EncountersUberList() {
         <ResourceListPage<Encounter>
             headerTitle="Encounters"
             resourceType="Encounter"
+            searchParams={{ profile: "https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-encounter" }}
             getTableColumns={() => [
                 {
                     title: 'Status',

--- a/src/containers/ImmunizationsUberList /index.tsx
+++ b/src/containers/ImmunizationsUberList /index.tsx
@@ -23,6 +23,7 @@ export function ImmunizationsUberList() {
         <ResourceListPage<Immunization>
             headerTitle="Immunizations"
             resourceType="Immunization"
+            searchParams={{ profile: 'https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-immunization' }}
             getTableColumns={() => [
                 {
                     title: 'Status',

--- a/src/containers/MedicationsUberList/index.tsx
+++ b/src/containers/MedicationsUberList/index.tsx
@@ -9,6 +9,7 @@ export function MedicationsUberList() {
         <ResourceListPage<Medication>
             headerTitle="Medications"
             resourceType="Medication"
+            searchParams={{ profile: 'https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-medication' }}
             getTableColumns={() => [
                 {
                     title: 'Status',

--- a/src/containers/ObservationsUberList/index.tsx
+++ b/src/containers/ObservationsUberList/index.tsx
@@ -26,6 +26,7 @@ export function ObservationsUberList() {
         <ResourceListPage<Observation>
             headerTitle="Observations"
             resourceType="Observation"
+            searchParams={{ profile: 'https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-observation' }}
             getTableColumns={() => [
                 {
                     title: 'Status',

--- a/src/containers/OrganizationsUberList/index.tsx
+++ b/src/containers/OrganizationsUberList/index.tsx
@@ -17,6 +17,7 @@ export function OrganizationsUberList() {
         <ResourceListPage<Organization>
             headerTitle={t`Organizations`}
             resourceType="Organization"
+            searchParams={{ profile: 'https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-organization' }}
             getTableColumns={() => [
                 {
                     title: <Trans>Name</Trans>,

--- a/src/containers/PatientsUberList/index.tsx
+++ b/src/containers/PatientsUberList/index.tsx
@@ -14,6 +14,7 @@ export function PatientUberList() {
         <ResourceListPage<Patient>
             headerTitle={t`Patients`}
             resourceType="Patient"
+            searchParams={{ profile: "https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-patient"}}
             getTableColumns={() => [
                 {
                     title: <Trans>Name</Trans>,

--- a/src/containers/PractitionerRolesUberList/index.tsx
+++ b/src/containers/PractitionerRolesUberList/index.tsx
@@ -44,7 +44,10 @@ export function PractitionerRolesUberList() {
         <ResourceListPage<PractitionerRole>
             headerTitle={t`Practitioner roles`}
             resourceType="PractitionerRole"
-            searchParams={{ _include: ['PractitionerRole:practitioner'] }}
+            searchParams={{
+                _include: ['PractitionerRole:practitioner'],
+                profile: 'https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-practitionerrole',
+            }}
             getTableColumns={() => [
                 {
                     title: <Trans>Practitioner</Trans>,

--- a/src/containers/PractitionersUberList /index.tsx
+++ b/src/containers/PractitionersUberList /index.tsx
@@ -15,6 +15,7 @@ export function PractitionersUberList() {
         <ResourceListPage<Practitioner>
             headerTitle={t`Practitioners`}
             resourceType="Practitioner"
+            searchParams={{ profile: 'https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-practitioner' }}
             getTableColumns={() => [
                 {
                     title: <Trans>Name</Trans>,

--- a/src/containers/ProceduresUberList/index.tsx
+++ b/src/containers/ProceduresUberList/index.tsx
@@ -21,6 +21,7 @@ export function ProceduresUberList() {
         <ResourceListPage<Procedure>
             headerTitle="Procedures"
             resourceType="Procedure"
+            searchParams={{ profile: 'https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-procedure' }}
             getTableColumns={() => [
                 {
                     title: 'Status',
@@ -86,7 +87,7 @@ export function ProceduresUberList() {
                     searchParam: 'encounter',
                     type: SearchBarColumnType.REFERENCE,
                     placeholder: 'Find by encounter',
-                    expression: 'Encounter',
+                    expression: 'Encounter?_profile=https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-encounter',
                     path: "class.display + ' - ' + period.start",
                     placement: ['search-bar', 'table'],
                 },


### PR DESCRIPTION
## Summary

Extends the WIP from #35 to filter PH Core resources consistently across the app:

- **UberLists** — add `searchParams.profile` for Organization, Practitioner, Procedure, Immunization, Observation, Medication, and PractitionerRole (Patient and Encounter were already covered)
- **Questionnaires** — add `_profile=` to `answerExpression` FHIR queries for Patient, Practitioner, Organization, Encounter, and Medication reference fields in connectathon forms and curated IPS
- **Procedure list filter** — Encounter reference filter in ProceduresUberList also uses `ph-core-encounter` profile

Profile URL pattern: `https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-{resource}`

This fixes empty Encounter selects in procedure/immunization/observation forms when non–PH Core encounters exist in the server.

## Test plan

- [ ] Reseed Aidbox (`build-seeds` + `watch-seeds`)
- [ ] Open each PH Core list page — only ph-core resources are shown
- [ ] Create/edit Procedure — Patient and Encounter dropdowns populate
- [ ] Create/edit Immunization — Patient, Encounter, Practitioner, Medication dropdowns populate
- [ ] Create/edit Observation — Patient, Encounter, Practitioner dropdowns populate
- [ ] Create/edit Encounter — Patient, Practitioner, Organization dropdowns populate
- [ ] Create/edit PractitionerRole — Practitioner and Organization dropdowns populate
- [ ] Curated IPS — Medication select shows only active ph-core medications