### PR TITLE
Restore encounter extract mapper (canonical PH Core profile)

### DIFF
--- a/resources/seeds/Mapping/encounter-create-extract-connectathon.yaml
+++ b/resources/seeds/Mapping/encounter-create-extract-connectathon.yaml
@@ -3,32 +3,92 @@ type: FHIRPath
 resourceType: Mapping
 body:
   "{% assign %}":
+    - id: "{{ %QuestionnaireResponse.answers('encounterId') }}"
+    - encounterIdentifier: "{{ %QuestionnaireResponse.answers('encounter-identifier') }}"
     - patientRef: "{{ %QuestionnaireResponse.answers('patient') }}"
     - practitionerRef: "{{ %QuestionnaireResponse.answers('practitioner') }}"
+    - participantType: "{{ %QuestionnaireResponse.answers('participant-type') }}"
     - organizationRef: "{{ %QuestionnaireResponse.answers('organization') }}"
-    - date: "{{ %QuestionnaireResponse.answers('date') }}"
+    - periodStart: "{{ %QuestionnaireResponse.answers('period-start') }}"
+    - periodEnd: "{{ %QuestionnaireResponse.answers('period-end') }}"
     - status: "{{ %QuestionnaireResponse.answers('status') }}"
-    - class: "{{ %QuestionnaireResponse.answers('class') }}"
-
+    - statusCode: "{{ %status.code }}"
+    - encounterClass: "{{ %QuestionnaireResponse.answers('class') }}"
+    - classDisplay: "{{ %encounterClass.display }}"
+    - encounterTypes: "{[ %QuestionnaireResponse.repeat(item).where(linkId='encounter-type').answer.valueCoding ]}"
+    - serviceType: "{{ %QuestionnaireResponse.answers('service-type') }}"
+    - priority: "{{ %QuestionnaireResponse.answers('priority') }}"
+    - reasonCodes: "{[ %QuestionnaireResponse.repeat(item).where(linkId='reason-code').answer.valueCoding ]}"
+    - narrativeDiv: "<div xmlns='http://www.w3.org/1999/xhtml'>PH Core Encounter — status {{ %statusCode }}, class {{ %classDisplay }}.</div>"
+    - addEncounter:
+        request:
+          "{% if %id.exists() %}":
+            url: /Encounter/{{ %id }}
+            method: PUT
+          "{% else %}":
+            url: /Encounter
+            method: POST
+        resource:
+          resourceType: Encounter
+          meta:
+            profile:
+              - https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-encounter
+          id:
+            "{% if %id.exists() %}": "{{ %id }}"
+          status: "{{ %statusCode }}"
+          class: "{{ %encounterClass }}"
+          text:
+            status: generated
+            div: "{{ %narrativeDiv }}"
+          "{% merge %}":
+            - "{% if %encounterIdentifier.exists() %}":
+                identifier:
+                  - system: https://fhir.doh.gov.ph/phcore/Identifier/encounter-id
+                    value: "{{ %encounterIdentifier }}"
+            - "{% if %patientRef.exists() %}":
+                subject: "{{ %patientRef }}"
+            - "{% if %practitionerRef.exists() or %participantType.exists() %}":
+                participant:
+                  - "{% merge %}":
+                      - "{% if %practitionerRef.exists() %}":
+                          individual: "{{ %practitionerRef }}"
+                      - "{% if %participantType.exists() %}":
+                          type:
+                            - coding:
+                                - "{{ %participantType }}"
+                              text: "{{ %participantType.display }}"
+            - "{% if %organizationRef.exists() %}":
+                serviceProvider: "{{ %organizationRef }}"
+            - "{% if %encounterTypes.exists() %}":
+                type:
+                  - "{% for encounterType in %encounterTypes %}":
+                      coding:
+                        - "{{ %encounterType }}"
+                      text: "{{ %encounterType.display }}"
+            - "{% if %serviceType.exists() %}":
+                serviceType:
+                  coding:
+                    - "{{ %serviceType }}"
+                  text: "{{ %serviceType.display }}"
+            - "{% if %priority.exists() %}":
+                priority:
+                  coding:
+                    - "{{ %priority }}"
+                  text: "{{ %priority.display }}"
+            - "{% if %reasonCodes.exists() %}":
+                reasonCode:
+                  - "{% for reasonCode in %reasonCodes %}":
+                      coding:
+                        - "{{ %reasonCode }}"
+                      text: "{{ %reasonCode.display }}"
+            - "{% if %periodStart.exists() or %periodEnd.exists() %}":
+                period:
+                  "{% merge %}":
+                    - "{% if %periodStart.exists() %}":
+                        start: "{{ %periodStart }}"
+                    - "{% if %periodEnd.exists() %}":
+                        end: "{{ %periodEnd }}"
   resourceType: Bundle
   type: transaction
   entry:
-    - request:
-        url: /Encounter
-        method: POST
-      resource:
-        meta:
-          profile:
-            - "urn://example.com/ph-core/fhir/StructureDefinition/ph-core-encounter"
-        resourceType: Encounter
-        status: "{{ %status.code }}"
-        class: "{{ %class }}"
-        subject:
-          "{% if %patientRef.exists() %}": "{{ %patientRef }}"
-        participant:
-          "{% if %practitionerRef.exists() %}":
-            - individual: "{{ %practitionerRef }}"
-        serviceProvider:
-          "{% if %organizationRef.exists() %}": "{{ %organizationRef }}"
-        period:
-          start: "{{ %date }}"
+    - "{{ %addEncounter }}"


### PR DESCRIPTION
## Summary
- Restore full `encounter-create-extract-connectathon` mapper regressed in `75edc44` (34-line stub with `urn://` profile).
- Canonical profile: `https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-encounter`.
- Fix `statusCode` to use `%status.code` from choice answers.

## Test plan
- [x] Create encounter via form → `meta.profile` is canonical URL
- [x] Encounter appears in Observation/Procedure/Immunization select (with `_profile` filter)
- [x] Edit `encounter-single-ex` preserves fields