### PR TITLE
Fix indigenous group multi-select save in patient extract mapper

### DIFF
--- a/resources/seeds/Mapping/patient-create-extract-connectathon.yaml
+++ b/resources/seeds/Mapping/patient-create-extract-connectathon.yaml
@@ -15,7 +15,7 @@ body:
     - nationalityGroup: "{[ %QuestionnaireResponse.item.where(linkId='nationality-group') ]}"
     - religion: "{{ %QuestionnaireResponse.answers('religion') }}"
     - indigenous: "{{ %QuestionnaireResponse.answers('indigenous') }}"
-    - indigenousGroupItems: "{[ %QuestionnaireResponse.item.where(linkId='indigenous-group') ]}"
+    - indigenousGroups: "{[ %QuestionnaireResponse.item.where(linkId='indigenous-group').answer.valueCoding ]}"
     - race: "{{ %QuestionnaireResponse.answers('race') }}"
     - maritalStatus: "{{ %QuestionnaireResponse.answers('marital-status') }}"
     - educationalAttainment: "{{ %QuestionnaireResponse.answers('educational-attainment') }}"
@@ -180,9 +180,7 @@ body:
                 valueBoolean:
                   "{% if %indigenous.code = 'yes' %}": true
                   "{% else %}": false
-            - "{% for indigenousGroupItem in %indigenousGroupItems %}":
-                "{% assign %}":
-                  - indigenousGroup: "{{ %indigenousGroupItem.answer.valueCoding.first() }}"
+            - "{% for indigenousGroup in %indigenousGroups %}":
                 "{% if %indigenous.code = 'yes' and %indigenousGroup.exists() %}":
                   url: "https://fhir.doh.gov.ph/phcore/StructureDefinition/indigenous-group"
                   valueCodeableConcept:

--- a/resources/seeds/Questionnaire/patient-create-connectathon.yaml
+++ b/resources/seeds/Questionnaire/patient-create-connectathon.yaml
@@ -199,7 +199,7 @@ item:
     initialExpression:
       language: text/fhirpath
       expression: >-
-        %Questionnaire.repeat(item).where(linkId='indigenous-group').answerOption.valueCoding.where(code in %Patient.extension.where(url='https://fhir.doh.gov.ph/phcore/StructureDefinition/indigenous-group').valueCodeableConcept.coding.code)
+        %Patient.extension.where(url='https://fhir.doh.gov.ph/phcore/StructureDefinition/indigenous-group').valueCodeableConcept.coding
 
   - linkId: race
     text: Race


### PR DESCRIPTION
## Summary

PR #42 fixed indigenous group **prefill** (questionnaire `initialExpression`, CodeSystem alignment, demo seed), but the extract mapper still only persisted the **first** selected value on save.

For `choice` + `repeats: true`, the QuestionnaireResponse has one item with multiple `answer` entries. The mapper looped over items and used `.answer.valueCoding.first()`, so only one `indigenous-group` extension was written to Patient. After save/reopen, the second selection disappeared.

This PR aligns the mapper with the pattern used elsewhere (e.g. `organization-type`, `specialty`): collect all codings from `item.where(linkId='indigenous-group').answer.valueCoding` and emit one extension per value.

Also simplifies `initialExpression` to read codings directly from Patient extensions (same approach as `Encounter.type.coding`).

## Changes

- `resources/seeds/Mapping/patient-create-extract-connectathon.yaml` — loop over `indigenousGroups` answers, not QR items + `.first()`
- `resources/seeds/Questionnaire/patient-create-connectathon.yaml` — `initialExpression` uses `%Patient.extension.where(...).valueCodeableConcept.coding`

## Test plan

- [x] Open patient edit for `patient-single-ex` (seed has Ilongots + Aetas) — both indigenous groups prefilled
- [x] Select two indigenous groups, save, reopen form — both values still present
- [x] `$extract` with QR containing one `indigenous-group` item and two `answer` entries → Patient has two `indigenous-group` extensions
- [x] Indigenous = No → no `indigenous-group` extensions on Patient

<img width="438" height="151" alt="Screenshot 2026-06-24 at 22 41 55" src="https://github.com/user-attachments/assets/e3bacddd-e2a9-44ab-81d4-7a69fd541085" />
