### PR TITLE
Restore Immunization and Practitioner connectathon extract mappers

### DIFF
--- a/resources/seeds/Immunization/immunization-single-ex.yaml
+++ b/resources/seeds/Immunization/immunization-single-ex.yaml
@@ -69,6 +69,11 @@ reasonCode:
         code: '429060002'
         display: Procedure to meet occupational requirement
     text: Procedure to meet occupational requirement
+  - coding:
+      - system: http://snomed.info/sct
+        code: '14740000'
+        display: Fear of needle
+    text: Fear of needle
 subpotentReason:
   - coding:
       - system: http://hl7.org/fhir/immunization-subpotent-reason

--- a/resources/seeds/Mapping/immunization-create-extract-connectathon.yaml
+++ b/resources/seeds/Mapping/immunization-create-extract-connectathon.yaml
@@ -3,75 +3,142 @@ type: FHIRPath
 resourceType: Mapping
 body:
   "{% assign %}":
+    - id: "{{ %QuestionnaireResponse.answers('immunizationId') }}"
     - patientRef: "{{ %QuestionnaireResponse.answers('patient') }}"
     - status: "{{ %QuestionnaireResponse.answers('status') }}"
+    - statusCode: "{{ %status.code }}"
+    - statusReason: "{{ %QuestionnaireResponse.answers('status-reason') }}"
+    - vaccineCode: "{{ %QuestionnaireResponse.answers('vaccine-code') }}"
+    - occurrenceDateTime: "{{ %QuestionnaireResponse.answers('occurrence-date-time') }}"
+    - encounterRef: "{{ %QuestionnaireResponse.answers('encounter') }}"
     - performer: "{{ %QuestionnaireResponse.answers('performer') }}"
     - performerFunction: "{{ %QuestionnaireResponse.answers('performer-function') }}"
-    - vaccineCode: "{{ %QuestionnaireResponse.answers('vaccine-code') }}"
-    - doseQuantity: "{{ %QuestionnaireResponse.answers('dose-quantity') }}"
-    - encounterRef: "{{ %QuestionnaireResponse.answers('encounter') }}"
-    - expirationDate: "{{ %QuestionnaireResponse.answers('expiration-date') }}"
-    - fundingSource: "{{ %QuestionnaireResponse.answers('funding-source') }}"
-    - isSubpotent: "{{ %QuestionnaireResponse.answers('is-subpotent') }}"
-    - lotNumber: "{{ %QuestionnaireResponse.answers('lot-number') }}"
-    - occurrenceDateTime: "{{ %QuestionnaireResponse.answers('occurrence-date-time') }}"
     - primarySource: "{{ %QuestionnaireResponse.answers('primary-source') }}"
+    - reportOrigin: "{{ %QuestionnaireResponse.answers('report-origin') }}"
+    - locationRef: "{{ %QuestionnaireResponse.answers('location') }}"
+    - lotNumber: "{{ %QuestionnaireResponse.answers('lot-number') }}"
+    - batchNumber: "{{ %QuestionnaireResponse.answers('batch-number') }}"
+    - administeredProduct: "{{ %QuestionnaireResponse.answers('administered-product') }}"
     - route: "{{ %QuestionnaireResponse.answers('route') }}"
     - site: "{{ %QuestionnaireResponse.answers('site') }}"
+    - fundingSource: "{{ %QuestionnaireResponse.answers('funding-source') }}"
+    - reasonCodes: "{[ %QuestionnaireResponse.item.where(linkId='reason-code').answer.valueCoding ]}"
+    - subpotentReason: "{{ %QuestionnaireResponse.answers('subpotent-reason') }}"
+    - programEligibility: "{{ %QuestionnaireResponse.answers('program-eligibility') }}"
+    - doseNumber: "{{ %QuestionnaireResponse.answers('dose-number') }}"
+    - targetDisease: "{{ %QuestionnaireResponse.answers('target-disease') }}"
     - note: "{{ %QuestionnaireResponse.answers('note') }}"
+    - vaccineDisplay: "{{ %vaccineCode.display | %vaccineCode.text | %vaccineCode.code }}"
+    - narrativeDiv: "<div xmlns='http://www.w3.org/1999/xhtml'>PH Core Immunization — {{ %vaccineDisplay }} — status {{ %statusCode }}.</div>"
     - addImmunization:
         request:
-          url: /Immunization
-          method: POST
+          "{% if %id.exists() %}":
+            url: /Immunization/{{ %id }}
+            method: PUT
+          "{% else %}":
+            url: /Immunization
+            method: POST
         resource:
+          resourceType: Immunization
           meta:
             profile:
-              - urn://example.com/ph-core/fhir/StructureDefinition/ph-core-immunization
+              - https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-immunization
               - http://hl7.org/fhir/uv/ips/StructureDefinition/Immunization-uv-ips
-          resourceType: Immunization
+          id:
+            "{% if %id.exists() %}": "{{ %id }}"
           patient: "{{ %patientRef }}"
-          status: "{{ %status.code }}"
-          "{% if %performer.exists() %}":
-            performer:
-              - actor: "{{ %performer }}"
-                "{% if %performerFunction.exists() %}":
-                  function:
-                    coding:
-                      - "{{ %performerFunction }}"
-          vaccineCode:
-            coding:
-              - "{{ %vaccineCode }}"
-            text: "{{ %vaccineCode.display }}"
-          doseQuantity: "{{ %doseQuantity }}"
-          encounter: "{{ %encounterRef }}"
-          occurrenceDateTime: "{{ %occurrenceDateTime }}"
-          expirationDate:
-            "{% if %expirationDate.exists() %}": "{{ %expirationDate }}"
-          fundingSource:
-            "{% if %fundingSource.exists() %}":
-              coding:
-                - "{{ %fundingSource }}"
-          isSubpotent:
-            "{% if %isSubpotent.exists() %}":
-              "{% if %isSubpotent.code = 'yes' %}": true
-              "{% else %}": false
-          lotNumber:
-            "{% if %lotNumber.exists() %}": "{{ %lotNumber }}"
-          primarySource:
-            "{% if %primarySource.exists() %}":
-              "{% if %primarySource.code = 'yes' %}": true
-              "{% else %}": false
-          route:
-            "{% if %route.exists() %}":
-              coding:
-                - "{{ %route }}"
-          site:
-            "{% if %site.exists() %}":
-              coding:
-                - "{{ %site }}"
-          note:
-            "{% if %note.exists() %}":
-              - text: "{{ %note }}"
+          status: "{{ %statusCode }}"
+          text:
+            status: generated
+            div: "{{ %narrativeDiv }}"
+          "{% merge %}":
+            - "{% if %statusReason.exists() %}":
+                statusReason:
+                  coding:
+                    - "{{ %statusReason }}"
+                  text: "{{ %statusReason.display }}"
+            - "{% if %vaccineCode.exists() %}":
+                vaccineCode:
+                  coding:
+                    - "{{ %vaccineCode }}"
+                  text: "{{ %vaccineDisplay }}"
+            - "{% if %occurrenceDateTime.exists() %}":
+                occurrenceDateTime: "{{ %occurrenceDateTime }}"
+            - "{% if %encounterRef.exists() %}":
+                encounter: "{{ %encounterRef }}"
+            - "{% if %performer.exists() %}":
+                performer:
+                  - actor: "{{ %performer }}"
+                    "{% if %performerFunction.exists() %}":
+                      function:
+                        coding:
+                          - "{{ %performerFunction }}"
+                        text: "{{ %performerFunction.display }}"
+            - "{% if %primarySource.exists() %}":
+                primarySource:
+                  "{% if %primarySource.code = 'yes' %}": true
+                  "{% else %}": false
+            - "{% if %reportOrigin.exists() %}":
+                reportOrigin:
+                  coding:
+                    - "{{ %reportOrigin }}"
+                  text: "{{ %reportOrigin.display }}"
+            - "{% if %locationRef.exists() %}":
+                location: "{{ %locationRef }}"
+            - "{% if %lotNumber.exists() %}":
+                lotNumber: "{{ %lotNumber }}"
+            - "{% if %batchNumber.exists() or %administeredProduct.exists() %}":
+                extension:
+                  - "{% if %batchNumber.exists() %}":
+                      url: https://fhir.doh.gov.ph/phcore/StructureDefinition/batch-number
+                      valueString: "{{ %batchNumber }}"
+                  - "{% if %administeredProduct.exists() %}":
+                      url: https://fhir.doh.gov.ph/phcore/StructureDefinition/administered-product
+                      valueReference: "{{ %administeredProduct }}"
+            - "{% if %route.exists() %}":
+                route:
+                  coding:
+                    - "{{ %route }}"
+                  text: "{{ %route.display }}"
+            - "{% if %site.exists() %}":
+                site:
+                  coding:
+                    - "{{ %site }}"
+                  text: "{{ %site.display }}"
+            - "{% if %fundingSource.exists() %}":
+                fundingSource:
+                  coding:
+                    - "{{ %fundingSource }}"
+                  text: "{{ %fundingSource.display }}"
+            - "{% if %reasonCodes.exists() %}":
+                reasonCode:
+                  - "{% for reasonCode in %reasonCodes %}":
+                      coding:
+                        - "{{ %reasonCode }}"
+                      text: "{{ %reasonCode.display }}"
+            - "{% if %subpotentReason.exists() %}":
+                subpotentReason:
+                  - coding:
+                      - "{{ %subpotentReason }}"
+                    text: "{{ %subpotentReason.display }}"
+            - "{% if %programEligibility.exists() %}":
+                programEligibility:
+                  - coding:
+                      - "{{ %programEligibility }}"
+                    text: "{{ %programEligibility.display }}"
+            - "{% if %doseNumber.exists() or %targetDisease.exists() %}":
+                protocolApplied:
+                  - "{% merge %}":
+                      - "{% if %doseNumber.exists() %}":
+                          doseNumberPositiveInt: "{{ %doseNumber }}"
+                      - "{% if %targetDisease.exists() %}":
+                          targetDisease:
+                            - coding:
+                                - "{{ %targetDisease }}"
+                              text: "{{ %targetDisease.display }}"
+            - "{% if %note.exists() %}":
+                note:
+                  - text: "{{ %note }}"
   resourceType: Bundle
   type: transaction
   entry:

--- a/resources/seeds/Mapping/practitioner-create-connectathon.yaml
+++ b/resources/seeds/Mapping/practitioner-create-connectathon.yaml
@@ -3,64 +3,108 @@ resourceType: Mapping
 type: FHIRPath
 body:
   "{% assign %}":
+    - id: "{{ %QuestionnaireResponse.answers('practitionerId') }}"
     - firstName: "{{ %QuestionnaireResponse.answers('first-name') }}"
+    - middleName: "{{ %QuestionnaireResponse.answers('middle-name') }}"
     - lastName: "{{ %QuestionnaireResponse.answers('last-name') }}"
     - gender: "{{ %QuestionnaireResponse.answers('gender') }}"
+    - practitionerGender: "{{ %Practitioner.gender }}"
     - birthDate: "{{ %QuestionnaireResponse.answers('birth-date') }}"
     - phone: "{{ %QuestionnaireResponse.answers('phone') }}"
     - email: "{{ %QuestionnaireResponse.answers('email') }}"
-    - addAddress: "{{ %QuestionnaireResponse.answers('add-address') }}"
-    - addressUse: "{{ %QuestionnaireResponse.answers('address-use') }}"
-    - addressRegion: "{{ %QuestionnaireResponse.answers('address-region') }}"
-    - province: "{{ %QuestionnaireResponse.answers('address-province') }}"
-    - cityMunicipality: "{{ %QuestionnaireResponse.answers('address-city-municipality') }}"
-    - barangay: "{{ %QuestionnaireResponse.answers('address-barangay') }}"
-
-  resourceType: Bundle
-  type: transaction
-  entry:
-    - "{% if %gender.exists() or %birthDate.exists() or %phone.exists() or %email.exists() or %firstName.exists() or %lastName.exists() or %addAddress %}":
+    - communicationLanguages: "{[ %QuestionnaireResponse.item.where(linkId='communication-language').answer.valueCoding ]}"
+    - addressGroupItems: "{[ %QuestionnaireResponse.item.where(linkId='address-group') ]}"
+    - addPractitioner:
         request:
-          method: POST
-          url: /Practitioner
+          "{% if %id.exists() %}":
+            url: /Practitioner/{{ %id }}
+            method: PUT
+          "{% else %}":
+            url: /Practitioner
+            method: POST
         resource:
           resourceType: Practitioner
           meta:
             profile:
-            - urn://example.com/ph-core/fhir/StructureDefinition/ph-core-practitioner
-          gender:
-            "{% if %gender.exists() %}": "{{ %gender.code }}"
-          birthDate:
-            "{% if %birthDate.exists() %}": "{{ %birthDate }}"
-          telecom:
-            "{% if %phone.exists() or %email.exists() %}":
-              - "{% if %phone.exists() %}":
-                  system: phone
-                  value: "{{ %phone }}"
-                  use: mobile
-              - "{% if %email.exists() %}":
-                  system: email
-                  value: "{{ %email }}"
-                  use: work
+              - https://fhir.doh.gov.ph/phcore/StructureDefinition/ph-core-practitioner
+          active: true
+          id:
+            "{% if %id.exists() %}": "{{ %id }}"
           name:
-            "{% if %firstName.exists() or %lastName.exists() %}":
-              - given:
-                  "{% if %firstName.exists() %}":
-                    - "{{ %firstName }}"
-                family: "{{ %lastName }}"
-          "{% if %addAddress %}":
-            address:
-              - use: "{{ %addressUse.code }}"
-                extension:
-                  - "{% if %addressRegion.exists() %}":
-                      url: urn://example.com/ph-core/fhir/StructureDefinition/region
-                      valueCoding: "{{ %addressRegion }}"
-                  - "{% if %province.exists() %}":
-                      url: urn://example.com/ph-core/fhir/StructureDefinition/province
-                      valueCoding: "{{ %province }}"
-                  - "{% if %cityMunicipality.exists() %}":
-                      url: urn://example.com/ph-core/fhir/StructureDefinition/city-municipality
-                      valueCoding: "{{ %cityMunicipality }}"
-                  - "{% if %barangay.exists() %}":
-                      url: urn://example.com/ph-core/fhir/StructureDefinition/barangay
-                      valueCoding: "{{ %barangay }}"
+            - use: official
+              "{% if %middleName.exists() %}":
+                given:
+                  - "{{ %firstName }}"
+                  - "{{ %middleName }}"
+              "{% else %}":
+                given:
+                  - "{{ %firstName }}"
+              family: "{{ %lastName }}"
+          "{% merge %}":
+            - "{% if %gender.exists() or %practitionerGender.exists() %}":
+                gender: "{{ iif(%gender.code.exists(), %gender.code, iif(%gender.exists(), %gender, %practitionerGender)) }}"
+            - "{% if %birthDate.exists() %}":
+                birthDate: "{{ %birthDate }}"
+            - "{% if %phone.exists() or %email.exists() %}":
+                telecom:
+                  - "{% if %phone.exists() %}":
+                      system: phone
+                      value: "{{ %phone }}"
+                      use: mobile
+                  - "{% if %email.exists() %}":
+                      system: email
+                      value: "{{ %email }}"
+                      use: work
+            - "{% if %communicationLanguages.exists() %}":
+                communication:
+                  - "{% for communicationLanguage in %communicationLanguages %}":
+                      coding:
+                        - "{{ %communicationLanguage }}"
+                      text: "{{ %communicationLanguage.display }}"
+            - "{% if %addressGroupItems.exists() %}":
+                address:
+                  - "{% for addressItem in %addressGroupItems %}":
+                      "{% assign %}":
+                        - addressUse: "{{ %addressItem.item.where(linkId='address-use').answer.valueCoding.first() }}"
+                        - addressLine: "{{ %addressItem.item.where(linkId='address-line').answer.valueString.first() }}"
+                        - addressRegion: "{{ %addressItem.item.where(linkId='address-region').answer.valueCoding.first() }}"
+                        - addressProvince: "{{ %addressItem.item.where(linkId='address-province').answer.valueCoding.first() }}"
+                        - addressCityMunicipality: "{{ %addressItem.item.where(linkId='address-city-municipality').answer.valueCoding.first() }}"
+                        - addressBarangay: "{{ %addressItem.item.where(linkId='address-barangay').answer.valueCoding.first() }}"
+                        - addressCity: "{{ %addressItem.item.where(linkId='address-city').answer.valueString.first() }}"
+                        - addressDistrict: "{{ %addressItem.item.where(linkId='address-district').answer.valueString.first() }}"
+                        - addressPostalCode: "{{ %addressItem.item.where(linkId='address-postal-code').answer.valueString.first() }}"
+                        - addressCountry: "{{ %addressItem.item.where(linkId='address-country').answer.valueCoding.first() }}"
+                      "{% if %addressUse.exists() or %addressLine.exists() or %addressRegion.exists() or %addressProvince.exists() or %addressCityMunicipality.exists() or %addressBarangay.exists() or %addressCity.exists() or %addressDistrict.exists() or %addressPostalCode.exists() or %addressCountry.exists() %}":
+                        "{% merge %}":
+                          - "{% if %addressUse.exists() %}":
+                              use: "{{ %addressUse.code }}"
+                          - "{% if %addressLine.exists() %}":
+                              line:
+                                - "{{ %addressLine }}"
+                          - "{% if %addressRegion.exists() or %addressProvince.exists() or %addressCityMunicipality.exists() or %addressBarangay.exists() %}":
+                              extension:
+                                - "{% if %addressRegion.exists() %}":
+                                    url: https://fhir.doh.gov.ph/phcore/StructureDefinition/region
+                                    valueCoding: "{{ %addressRegion }}"
+                                - "{% if %addressProvince.exists() %}":
+                                    url: https://fhir.doh.gov.ph/phcore/StructureDefinition/province
+                                    valueCoding: "{{ %addressProvince }}"
+                                - "{% if %addressCityMunicipality.exists() %}":
+                                    url: https://fhir.doh.gov.ph/phcore/StructureDefinition/city-municipality
+                                    valueCoding: "{{ %addressCityMunicipality }}"
+                                - "{% if %addressBarangay.exists() %}":
+                                    url: https://fhir.doh.gov.ph/phcore/StructureDefinition/barangay
+                                    valueCoding: "{{ %addressBarangay }}"
+                          - "{% if %addressCity.exists() %}":
+                              city: "{{ %addressCity }}"
+                          - "{% if %addressDistrict.exists() %}":
+                              district: "{{ %addressDistrict }}"
+                          - "{% if %addressPostalCode.exists() %}":
+                              postalCode: "{{ %addressPostalCode }}"
+                          - "{% if %addressCountry.exists() %}":
+                              country: "{{ iif(%addressCountry.code.exists(), %addressCountry.code, %addressCountry) }}"
+  resourceType: Bundle
+  type: transaction
+  entry:
+    - "{{ %addPractitioner }}"

--- a/resources/seeds/Questionnaire/immunization-create-connectathon.yaml
+++ b/resources/seeds/Questionnaire/immunization-create-connectathon.yaml
@@ -65,7 +65,27 @@ item:
   - linkId: status-reason
     text: Status reason
     type: choice
-    answerValueSet: http://hl7.org/fhir/ValueSet/immunization-status-reason
+    enableWhen:
+      - answerCoding:
+          code: not-done
+          system: http://hl7.org/fhir/event-status
+        operator: "="
+        question: status
+    # TODO: uncomment answerValueSet when tx.fhirlab.net expands immunization-status-reason reliably
+    # answerValueSet: http://hl7.org/fhir/ValueSet/immunization-status-reason
+    answerOption:
+      - valueCoding:
+          system: http://terminology.hl7.org/CodeSystem/v3-ActReason
+          code: MEDPREC
+          display: Medical precaution
+      - valueCoding:
+          system: http://terminology.hl7.org/CodeSystem/v3-ActReason
+          code: PATOBJ
+          display: Patient objection
+      - valueCoding:
+          system: http://terminology.hl7.org/CodeSystem/v3-ActReason
+          code: OSTOCK
+          display: Product out of stock
     initialExpression:
       language: text/fhirpath
       expression: "%Immunization.statusReason.coding.first()"
@@ -225,7 +245,17 @@ item:
     text: Reason
     type: choice
     repeats: true
-    answerValueSet: http://hl7.org/fhir/ValueSet/immunization-reason
+    # TODO: uncomment answerValueSet when tx.fhirlab.net expands immunization-reason reliably
+    # answerValueSet: http://hl7.org/fhir/ValueSet/immunization-reason
+    answerOption:
+      - valueCoding:
+          system: http://snomed.info/sct
+          code: "429060002"
+          display: Procedure to meet occupational requirement
+      - valueCoding:
+          system: http://snomed.info/sct
+          code: "14740000"
+          display: Fear of needle
     initialExpression:
       language: text/fhirpath
       expression: "%Immunization.reasonCode.coding"

--- a/resources/seeds/Questionnaire/practitioner-create-connectathon.yaml
+++ b/resources/seeds/Questionnaire/practitioner-create-connectathon.yaml
@@ -90,7 +90,6 @@ item:
         - code: phoneWidget
     initialExpression:
       language: text/fhirpath
-      language: text/fhirpath
       expression: >-
         iif(
           %Practitioner.telecom.where(system='phone').value.exists(),
@@ -121,8 +120,7 @@ item:
           display: Filipino
     initialExpression:
       language: text/fhirpath
-      expression: |-
-        %Questionnaire.repeat(item).where(linkId='communication-language').answerOption.valueCoding.where(code in %Practitioner.communication.coding.code)
+      expression: "%Practitioner.communication.coding"
 
   - linkId: address-group
     text: Address


### PR DESCRIPTION
## Summary

- **Immunization** — restore full `$extract` mapper after regression in #24 (`f4b19df` scoped the PR back to a 78-line POST-only stub). Brings back PUT/edit via `immunizationId`, `statusReason`, multi-select `reasonCode`, `occurrence-date-time`, report origin, location, batch/administered-product extensions, protocol applied, and canonical PH Core profile. Questionnaire: `answerOption` stubs for reason/status-reason, `enableWhen` for status-reason when `not-done`, `initialExpression` for reasons. Seed: second reason code for multi-select round-trip.
- **Practitioner** — align mapper with FCE questionnaire (same class of bug as pre-#29 PractitionerRole): `address-group` loop, `communication-language` via `.answer.valueCoding`, PUT/edit via `practitionerId`, canonical `https://fhir.doh.gov.ph/phcore/...` profiles. PH Core uses `communication.coding` (not `language.coding`). Questionnaire: fix duplicate `language:` on phone field; `initialExpression` for communication languages.

## Test plan

- [x] Reload seeds in Aidbox (`watch-seeds` or DB rebuild)
- [x] **Immunization** — `$populate` `immunization-single-ex`: reason codes (2), status-reason hidden for `completed`
- [x] **Immunization** — `$extract` round-trip: both `reasonCode` entries saved; edit existing immunization via PUT
- [x] **Immunization** — create with `status: not-done`: status-reason visible and persisted
- [x] **Practitioner** — `$populate` `practitioner-single-ex`: address group + communication languages (`en`, `fil`)
- [x] **Practitioner** — `$extract` round-trip: languages and address fields persist on edit