### PR TITLE
Add emergency contact address to patient connectathon form

### DIFF
--- a/resources/seeds/Mapping/patient-create-extract-connectathon.yaml
+++ b/resources/seeds/Mapping/patient-create-extract-connectathon.yaml
@@ -110,16 +110,16 @@ body:
                           - "{% if %addressItem.exists() %}":
                               address:
                                 "{% assign %}":
-                                  - addressUse: "{{ %addressItem.item.where(linkId='9zZP5YXz').answer.valueCoding.first() }}"
-                                  - addressLine: "{{ %addressItem.item.where(linkId='aOuEfx2o').answer.valueString.first() }}"
-                                  - addressRegion: "{{ %addressItem.item.where(linkId='A3C2gl0r').answer.valueCoding.first() }}"
-                                  - addressProvince: "{{ %addressItem.item.where(linkId='FjdwA17T').answer.valueCoding.first() }}"
-                                  - addressCityMunicipality: "{{ %addressItem.item.where(linkId='LnBTHFO1').answer.valueCoding.first() }}"
-                                  - addressBarangay: "{{ %addressItem.item.where(linkId='gYn_JAfL').answer.valueCoding.first() }}"
-                                  - addressCity: "{{ %addressItem.item.where(linkId='x_S9l3tQ').answer.valueString.first() }}"
-                                  - addressDistrict: "{{ %addressItem.item.where(linkId='0qAQ3uME').answer.valueString.first() }}"
-                                  - addressPostalCode: "{{ %addressItem.item.where(linkId='D9uI25LH').answer.valueString.first() }}"
-                                  - addressCountry: "{{ %addressItem.item.where(linkId='HVVM03-Q').answer.valueCoding.first() }}"
+                                  - addressUse: "{{ %addressItem.item.where(linkId='contact-address-use').answer.valueCoding.first() }}"
+                                  - addressLine: "{{ %addressItem.item.where(linkId='contact-address-line').answer.valueString.first() }}"
+                                  - addressRegion: "{{ %addressItem.item.where(linkId='contact-address-region').answer.valueCoding.first() }}"
+                                  - addressProvince: "{{ %addressItem.item.where(linkId='contact-address-province').answer.valueCoding.first() }}"
+                                  - addressCityMunicipality: "{{ %addressItem.item.where(linkId='contact-address-city-municipality').answer.valueCoding.first() }}"
+                                  - addressBarangay: "{{ %addressItem.item.where(linkId='contact-address-barangay').answer.valueCoding.first() }}"
+                                  - addressCity: "{{ %addressItem.item.where(linkId='contact-address-city').answer.valueString.first() }}"
+                                  - addressDistrict: "{{ %addressItem.item.where(linkId='contact-address-district').answer.valueString.first() }}"
+                                  - addressPostalCode: "{{ %addressItem.item.where(linkId='contact-address-postal-code').answer.valueString.first() }}"
+                                  - addressCountry: "{{ %addressItem.item.where(linkId='contact-address-country').answer.valueCoding.first() }}"
                                 "{% if %addressUse.exists() or %addressLine.exists() or %addressRegion.exists() or %addressProvince.exists() or %addressCityMunicipality.exists() or %addressBarangay.exists() or %addressCity.exists() or %addressDistrict.exists() or %addressPostalCode.exists() or %addressCountry.exists() %}":
                                   "{% merge %}":
                                     - "{% if %addressUse.exists() %}":

--- a/resources/seeds/Mapping/patient-create-extract-connectathon.yaml
+++ b/resources/seeds/Mapping/patient-create-extract-connectathon.yaml
@@ -92,7 +92,8 @@ body:
                         - contactRelationship: "{{ %contactItem.item.where(linkId='contact-relationship').answer.valueCoding.first() }}"
                         - contactFirstName: "{{ %contactItem.item.where(linkId='contact-first-name').answer.valueString.first() }}"
                         - contactLastName: "{{ %contactItem.item.where(linkId='contact-last-name').answer.valueString.first() }}"
-                      "{% if %contactRelationship.exists() or %contactFirstName.exists() or %contactLastName.exists() %}":
+                        - addressItem: "{{ %contactItem.item.where(linkId='contact-address') }}"
+                      "{% if %contactRelationship.exists() or %contactFirstName.exists() or %contactLastName.exists() or %addressItem.exists() %}":
                         "{% merge %}":
                           - "{% if %contactRelationship.exists() %}":
                               relationship:
@@ -106,6 +107,48 @@ body:
                                   - "{% if %contactFirstName.exists() %}": "{{ %contactFirstName }}"
                                 family:
                                   "{% if %contactLastName.exists() %}": "{{ %contactLastName }}"
+                          - "{% if %addressItem.exists() %}":
+                              address:
+                                "{% assign %}":
+                                  - addressUse: "{{ %addressItem.item.where(linkId='9zZP5YXz').answer.valueCoding.first() }}"
+                                  - addressLine: "{{ %addressItem.item.where(linkId='aOuEfx2o').answer.valueString.first() }}"
+                                  - addressRegion: "{{ %addressItem.item.where(linkId='A3C2gl0r').answer.valueCoding.first() }}"
+                                  - addressProvince: "{{ %addressItem.item.where(linkId='FjdwA17T').answer.valueCoding.first() }}"
+                                  - addressCityMunicipality: "{{ %addressItem.item.where(linkId='LnBTHFO1').answer.valueCoding.first() }}"
+                                  - addressBarangay: "{{ %addressItem.item.where(linkId='gYn_JAfL').answer.valueCoding.first() }}"
+                                  - addressCity: "{{ %addressItem.item.where(linkId='x_S9l3tQ').answer.valueString.first() }}"
+                                  - addressDistrict: "{{ %addressItem.item.where(linkId='0qAQ3uME').answer.valueString.first() }}"
+                                  - addressPostalCode: "{{ %addressItem.item.where(linkId='D9uI25LH').answer.valueString.first() }}"
+                                  - addressCountry: "{{ %addressItem.item.where(linkId='HVVM03-Q').answer.valueCoding.first() }}"
+                                "{% if %addressUse.exists() or %addressLine.exists() or %addressRegion.exists() or %addressProvince.exists() or %addressCityMunicipality.exists() or %addressBarangay.exists() or %addressCity.exists() or %addressDistrict.exists() or %addressPostalCode.exists() or %addressCountry.exists() %}":
+                                  "{% merge %}":
+                                    - "{% if %addressUse.exists() %}":
+                                        use: "{{ %addressUse.code }}"
+                                    - "{% if %addressLine.exists() %}":
+                                        line:
+                                          - "{{ %addressLine }}"
+                                    - "{% if %addressRegion.exists() or %addressProvince.exists() or %addressCityMunicipality.exists() or %addressBarangay.exists() %}":
+                                        extension:
+                                          - "{% if %addressRegion.exists() %}":
+                                              url: "https://fhir.doh.gov.ph/phcore/StructureDefinition/region"
+                                              valueCoding: "{{ %addressRegion }}"
+                                          - "{% if %addressProvince.exists() %}":
+                                              url: "https://fhir.doh.gov.ph/phcore/StructureDefinition/province"
+                                              valueCoding: "{{ %addressProvince }}"
+                                          - "{% if %addressCityMunicipality.exists() %}":
+                                              url: "https://fhir.doh.gov.ph/phcore/StructureDefinition/city-municipality"
+                                              valueCoding: "{{ %addressCityMunicipality }}"
+                                          - "{% if %addressBarangay.exists() %}":
+                                              url: "https://fhir.doh.gov.ph/phcore/StructureDefinition/barangay"
+                                              valueCoding: "{{ %addressBarangay }}"
+                                    - "{% if %addressCity.exists() %}":
+                                        city: "{{ %addressCity }}"
+                                    - "{% if %addressDistrict.exists() %}":
+                                        district: "{{ %addressDistrict }}"
+                                    - "{% if %addressPostalCode.exists() %}":
+                                        postalCode: "{{ %addressPostalCode }}"
+                                    - "{% if %addressCountry.exists() %}":
+                                        country: "{{ iif(%addressCountry.code.exists(), %addressCountry.code, %addressCountry) }}"
             - "{% if %addressGroupItems.exists() %}":
                 address:
                   - "{% for addressItem in %addressGroupItems %}":

--- a/resources/seeds/Questionnaire/patient-create-connectathon.yaml
+++ b/resources/seeds/Questionnaire/patient-create-connectathon.yaml
@@ -509,7 +509,7 @@ item:
           expression: "%context.address"
           name: address
         item:
-          - linkId: 9zZP5YXz
+          - linkId: contact-address-use
             text: "Address use"
             type: choice
             answerOption:
@@ -536,16 +536,16 @@ item:
             initialExpression:
               language: "text/fhirpath"
               expression: |-
-                %Questionnaire.repeat(item).where(linkId='address-use').answerOption.valueCoding.where(code=%context.use).first()
+                %Questionnaire.repeat(item).where(linkId='contact-address-use').answerOption.valueCoding.where(code=%context.use).first()
 
-          - linkId: aOuEfx2o
+          - linkId: contact-address-line
             text: "Address Line"
             type: string
             initialExpression:
               language: "text/fhirpath"
               expression: "%context.line.first()"
 
-          - linkId: A3C2gl0r
+          - linkId: contact-address-region
             text: Region
             type: choice
             answerOption:
@@ -562,7 +562,7 @@ item:
               expression: |-
                 %context.extension('https://fhir.doh.gov.ph/phcore/StructureDefinition/region').valueCoding
 
-          - linkId: FjdwA17T
+          - linkId: contact-address-province
             text: Province
             type: choice
             answerOption:
@@ -579,7 +579,7 @@ item:
               expression: |-
                 %context.extension('https://fhir.doh.gov.ph/phcore/StructureDefinition/province').valueCoding
 
-          - linkId: LnBTHFO1
+          - linkId: contact-address-city-municipality
             text: "City Municipality"
             type: choice
             answerOption:
@@ -596,7 +596,7 @@ item:
               expression: |-
                 %context.extension('https://fhir.doh.gov.ph/phcore/StructureDefinition/city-municipality').valueCoding
 
-          - linkId: gYn_JAfL
+          - linkId: contact-address-barangay
             text: Barangay
             type: choice
             answerOption:
@@ -613,28 +613,28 @@ item:
               expression: |-
                 %context.extension('https://fhir.doh.gov.ph/phcore/StructureDefinition/barangay').valueCoding
 
-          - linkId: x_S9l3tQ
+          - linkId: contact-address-city
             text: City
             type: string
             initialExpression:
               language: "text/fhirpath"
               expression: "%context.city"
 
-          - linkId: 0qAQ3uME
+          - linkId: contact-address-district
             text: District
             type: string
             initialExpression:
               language: "text/fhirpath"
               expression: "%context.district"
 
-          - linkId: D9uI25LH
+          - linkId: contact-address-postal-code
             text: "Postal Code"
             type: string
             initialExpression:
               language: "text/fhirpath"
               expression: "%context.postalCode"
 
-          - linkId: HVVM03-Q
+          - linkId: contact-address-country
             text: Country
             type: choice
             answerOption:

--- a/resources/seeds/Questionnaire/patient-create-connectathon.yaml
+++ b/resources/seeds/Questionnaire/patient-create-connectathon.yaml
@@ -499,3 +499,153 @@ item:
         initialExpression:
           language: "text/fhirpath"
           expression: "%context.name.family"
+
+      - linkId: contact-address
+        text: Address
+        type: group
+        repeats: false
+        itemPopulationContext:
+          language: "text/fhirpath"
+          expression: "%context.address"
+          name: address
+        item:
+          - linkId: 9zZP5YXz
+            text: "Address use"
+            type: choice
+            answerOption:
+              - valueCoding:
+                  system: "http://hl7.org/fhir/address-use"
+                  code: home
+                  display: Home
+              - valueCoding:
+                  system: "http://hl7.org/fhir/address-use"
+                  code: work
+                  display: Work
+              - valueCoding:
+                  system: "http://hl7.org/fhir/address-use"
+                  code: temp
+                  display: Temporary
+              - valueCoding:
+                  system: "http://hl7.org/fhir/address-use"
+                  code: old
+                  display: "Old / Incorrect"
+              - valueCoding:
+                  system: "http://hl7.org/fhir/address-use"
+                  code: billing
+                  display: Billing
+            initialExpression:
+              language: "text/fhirpath"
+              expression: |-
+                %Questionnaire.repeat(item).where(linkId='address-use').answerOption.valueCoding.where(code=%context.use).first()
+
+          - linkId: aOuEfx2o
+            text: "Address Line"
+            type: string
+            initialExpression:
+              language: "text/fhirpath"
+              expression: "%context.line.first()"
+
+          - linkId: A3C2gl0r
+            text: Region
+            type: choice
+            answerOption:
+              - valueCoding:
+                  system: "https://psa.gov.ph/classification/psgc"
+                  code: "0102800000"
+                  display: "Ilocos Norte"
+              - valueCoding:
+                  system: "https://psa.gov.ph/classification/psgc"
+                  code: "1300000000"
+                  display: "National Capital Region (NCR)"
+            initialExpression:
+              language: "text/fhirpath"
+              expression: |-
+                %context.extension('https://fhir.doh.gov.ph/phcore/StructureDefinition/region').valueCoding
+
+          - linkId: FjdwA17T
+            text: Province
+            type: choice
+            answerOption:
+              - valueCoding:
+                  system: "https://psa.gov.ph/classification/psgc"
+                  code: "1705100000"
+                  display: "Occidental Mindoro"
+              - valueCoding:
+                  system: "https://psa.gov.ph/classification/psgc"
+                  code: "0349000000"
+                  display: "Pampanga"
+            initialExpression:
+              language: "text/fhirpath"
+              expression: |-
+                %context.extension('https://fhir.doh.gov.ph/phcore/StructureDefinition/province').valueCoding
+
+          - linkId: LnBTHFO1
+            text: "City Municipality"
+            type: choice
+            answerOption:
+              - valueCoding:
+                  system: "https://psa.gov.ph/classification/psgc"
+                  code: "1380100000"
+                  display: "City of Caloocan"
+              - valueCoding:
+                  system: "https://psa.gov.ph/classification/psgc"
+                  code: "1380600000"
+                  display: "City of Manila"
+            initialExpression:
+              language: "text/fhirpath"
+              expression: |-
+                %context.extension('https://fhir.doh.gov.ph/phcore/StructureDefinition/city-municipality').valueCoding
+
+          - linkId: gYn_JAfL
+            text: Barangay
+            type: choice
+            answerOption:
+              - valueCoding:
+                  system: "https://psa.gov.ph/classification/psgc"
+                  code: "1380100001"
+                  display: "Barangay 1, City of Caloocan"
+              - valueCoding:
+                  system: "https://psa.gov.ph/classification/psgc"
+                  code: "1380603000"
+                  display: "Quiapo, City of Manila"
+            initialExpression:
+              language: "text/fhirpath"
+              expression: |-
+                %context.extension('https://fhir.doh.gov.ph/phcore/StructureDefinition/barangay').valueCoding
+
+          - linkId: x_S9l3tQ
+            text: City
+            type: string
+            initialExpression:
+              language: "text/fhirpath"
+              expression: "%context.city"
+
+          - linkId: 0qAQ3uME
+            text: District
+            type: string
+            initialExpression:
+              language: "text/fhirpath"
+              expression: "%context.district"
+
+          - linkId: D9uI25LH
+            text: "Postal Code"
+            type: string
+            initialExpression:
+              language: "text/fhirpath"
+              expression: "%context.postalCode"
+
+          - linkId: HVVM03-Q
+            text: Country
+            type: choice
+            answerOption:
+              - valueCoding:
+                  system: urn:iso:std:iso:3166
+                  code: "PH"
+                  display: Philippines
+              - valueCoding:
+                  system: urn:iso:std:iso:3166
+                  code: "US"
+                  display: "United States of America"
+            initialExpression:
+              language: text/fhirpath
+              expression: "%context.country | 'PH'"


### PR DESCRIPTION
**Ref:** https://github.com/beda-software/beda.fhirlab.net/issues/47

## Summary

- Add `contact-address` group under `contact-group` (Emergency Contact) in `patient-create-connectathon` questionnaire — same PH Core address fields as patient `address-group` (use, line, region, province, city/municipality, barangay, city, district, postal code, country), with `itemPopulationContext: %context.address`
- Extend `patient-create-extract-connectathon` mapper to persist `Patient.contact.address` on `$extract`
- Use readable `contact-address-*` linkIds (instead of FCE-generated ids from Aidbox UI export)

## Test plan

- [x] Reload seeds in Aidbox (`watch-seeds` or DB rebuild)
- [x] Open patient form — Emergency Contact section shows Address fields
- [x] `$populate` patient with `contact.address` — address fields prefilled (line, city, postal, PSGC extensions)
- [x] `$extract` round-trip — `Patient.contact[0].address` saved correctly
- [x] Create new patient with emergency contact + address via form UI